### PR TITLE
Build DynAdjust on Ubuntu 18.04

### DIFF
--- a/dynadjust/CMakeLists.release.txt
+++ b/dynadjust/CMakeLists.release.txt
@@ -14,7 +14,7 @@ if(UNIX)
    set(DNA_PROGRAM_PREFIX "dna")
 endif(UNIX)
 
-set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
+set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_MODULE_PATH}")
 set (CMAKE_CXX_STANDARD 11)
 add_definitions(-Wno-deprecated-declarations)
 

--- a/dynadjust/FindXSD_ubuntu.cmake
+++ b/dynadjust/FindXSD_ubuntu.cmake
@@ -4,9 +4,6 @@
 # XSD_INCLUDE_DIR - where to find dom/dom.hpp, etc.
 # XSD_FOUND       - Do not attempt to use Xerces if "no" or undefined.
 
-# SET THE ROOT DIRECTORY WHERE XERCES-C++ IS INSTALLED
-SET(XSD_INCLUDE_DIR /usr/include/)
-
 FIND_PATH(XSD_INCLUDE_DIR xsd/cxx/config.hxx
     PATHS "${XERCES_INCLUDE_DIR}")
 

--- a/dynadjust/FindXercesC_ubuntu.cmake
+++ b/dynadjust/FindXercesC_ubuntu.cmake
@@ -5,12 +5,11 @@
 # XERCESC_LIBRARY     - List of fully qualified libraries to link against when using Xerces.
 # XERCESC_FOUND       - Do not attempt to use Xerces if "no" or undefined.
 
-# SET THE ROOT DIRECTORY WHERE XERCES-C++ IS INSTALLED
-SET(XERCESC_ROOT_DIR /usr/include/xerces-c)
+SET (XERCESC_ROOT_DIR /usr)
 
-# DO NOT CHANGE
-SET (XERCESC_LIBRARY_DIR /usr/lib/x86_64-linux-gnu)
-SET (XERCESC_INCLUDE_DIR /usr/include/xercesc)
+SET (XERCESC_LIBRARY_DIR ${XERCESC_ROOT_DIR}/lib)
+
+SET (XERCESC_INCLUDE_DIR ${XERCESC_ROOT_DIR}/include)
 
 FIND_PATH(XERCESC_INCLUDE_DIR dom/DOM.hpp
     PATH_SUFFIXES xerces-c

--- a/dynadjust/make_dynadjust_gcc_ubuntu.sh
+++ b/dynadjust/make_dynadjust_gcc_ubuntu.sh
@@ -3,27 +3,50 @@
 ################################################################################
 #
 # This script configures the environment and installs DynAdjust using:
-#   gcc 7.2.1
-#   boost 1.58
-#   xerces-c 3.1.4
+#
+#   g++: 		7.3.0
+#   boost: 		BOOST_LIB_VERSION "1_65_1"
+#   xerces-c:		3.2.0
+#   XSD:		CodeSynthesis XSD XML Schema to C++ compiler 4.0.0
+#   MKL:		INTEL_MKL_VERSION 20180001
+#
+# This script builds and installs DynAdjust on Ubuntu Linux machine:
+#
+# 	$ lsb_release -a
+# 	No LSB modules are available.
+# 	Distributor ID: Ubuntu
+# 	Description:    Ubuntu 18.04.1 LTS
+# 	Release:        18.04
+# 	Codename:       bionic
+#
+# Perhaps could ONLY build release version?
+#
+#	$ ./make_dynadjust_gcc_ubuntu.sh release
 #
 ################################################################################
 
 # Needed in order to find boost installation
-export BOOST_ROOT=/opt/boost/gcc/1.58
+export BOOST_ROOT=/usr
+
+# Needed in order to find XSD
+export XSD_INCLUDE_DIR=/usr/include
 
 if [ -d "./build-gcc" ]; then
     cd ./build-gcc
+    if [ -f "./Makefile" ]; then
+        make clean
+    fi
     rm -rf CMakeCache.txt CMakeFiles cmake_install.cmake dynadjust Makefile
-    make distclean
 else
     mkdir ./build-gcc
     cd ./build-gcc
 fi
 
-cp ../FindXercesC_ubunutu.cmake ./
-cp ../FindMKL_ubuntu.cmake ./
-cp ../FindXSD.cmake ./
+cp ../FindXercesC_ubuntu.cmake ./FindXercesC.cmake
+# XercesC is special
+
+cp ../FindMKL.cmake ./
+cp ../FindXSD_ubuntu.cmake ./FindXSD.cmake
 
 REL_BUILD_TYPE="Release"
 DBG_BUILD_TYPE="Debug"
@@ -91,7 +114,7 @@ fi
 
 cmake ../
 
-make -j
+make -j 4
 
 #exit
 
@@ -108,6 +131,10 @@ fi
 
 if [ ! -d $DYNADJUST_INSTALL_PATH ]; then
     sudo mkdir $DYNADJUST_INSTALL_PATH
+fi
+
+if [ ! -d ~/bin ]; then
+    mkdir ~/bin
 fi
 
 echo "Copying libraries and binaries to $DYNADJUST_INSTALL_PATH ..."

--- a/packer/adjust.json
+++ b/packer/adjust.json
@@ -1,0 +1,31 @@
+{
+    "variables": {
+        "aws_access_key": "{{env `AWS_ACCESS_KEY`}}",
+        "aws_secret_key": "{{env `AWS_SECRET_KEY`}}"
+    },
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "access_key": "{{user `aws_access_key`}}",
+            "secret_key": "{{user `aws_secret_key`}}",
+            "region": "ap-southeast-2",
+            "source_ami": "ami-07a3bd4944eb120a0",
+            "instance_type": "t2.large",
+            "ssh_username": "ubuntu",
+            "ami_name": "Geodesy Surveyor {{timestamp}}",
+            "ami_description": "based on Ubuntu Server 18.04 LTS (HVM), SSD Volume Type - ami-07a3bd4944eb120a0",
+            "associate_public_ip_address": true,
+            "tags": {
+                "Name": "DynAdjust",
+                "Owner": "Geodesy"
+            }
+        }
+    ],
+
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "./provisioners.sh"
+        }
+    ]
+}

--- a/packer/provisioners.sh
+++ b/packer/provisioners.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+sudo add-apt-repository multiverse
+sudo apt-get -y update
+
+sudo apt-get -y install p7zip
+sudo apt-get -y install libboost-all-dev
+sudo apt-get -y install libxerces-c-dev
+sudo apt-get -y install cmake
+sudo apt-get -y install make
+sudo apt-get -y install g++
+sudo apt-get -y install xsdcxx
+sudo apt-get -y install git
+sudo apt-get -y install xorg
+sudo apt-get -y install vim-gnome
+
+wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
+sudo sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
+sudo apt-get -y update
+sudo apt-get -y install intel-mkl-64bit-2018.1-038
+

--- a/packer/shell.nix
+++ b/packer/shell.nix
@@ -1,0 +1,47 @@
+let
+  defaultPkgs = import <nixpkgs> {};
+  pinnedPkgs = import (defaultPkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    rev = "6141939d6e0a77c84905efd560c03c3032164ef1"; # 7 November 2018
+    sha256 = "1nz2z71qvjna8ki5jq4kl6pnl716hj66a0gs49l18q24pj2kbjwh";
+  }) {};
+in
+  { nixpkgs ? pinnedPkgs }:
+
+  let
+    pkgs = if nixpkgs == null then defaultPkgs else pinnedPkgs;
+
+    devEnv = with pkgs; buildEnv {
+      name = "devEnv";
+      paths = [
+        awscli
+        cacert
+        jq
+        terraform_0_11
+        packer
+        pythonPackages.credstash
+      ];
+    };
+  in
+  pkgs.runCommand "setupEnv" {
+    buildInputs = [
+      devEnv
+    ];
+    shellHook = ''
+    export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+
+    # workaround due to some bug in nixpkgs
+    function credstash() {
+    "${pkgs.pythonPackages.credstash}/bin/credstash.py" $@
+    }
+    export -f credstash
+
+    export LS_COLORS=$LS_COLORS:'di=1;4;36'
+    parse_git_branch() {
+    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/'
+    }
+    export PS1="\n\[\033[1;32m\]\e[35m\e[4m$(parse_git_branch)\e[24m\e[0m \w\$ \[\033[0m\]"
+    '';
+  } ""
+


### PR DESCRIPTION
Dear Nick, Craig:

Against both Ubuntun 16.04 and Ubuntu 18.04, DynAdjust release version could be successfully built without no C++ source code touch.

However, the CMake and XercesC behave differently on Ubuntun 16.04 and Ubuntu 18.04.

1. I built an AWS ami for Josh, Craig and Nick to quickly build a machine to run your own DynAdjust.
2. The DynAdjust release version could be immediately built on Ubuntu 18.04 machine.

Ted


