### PR TITLE
Add .gitignore to ignore CMake generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# CMake generated files
+CMakeCache.txt
+CMakeFiles
+Makefile
+cmake_install.cmake
+
+# Compiled Dynamic libraries
+*.so
+
+# ignore compiled dynadjust wrappers & binaries
+dynadjust/build-gcc/
+dynadjust/dynadjust/dna*wrapper/
+dynadjust/dynadjust/dynadjust/dynadjust
+


### PR DESCRIPTION
I've added a [`.gitignore` file](https://github.com/jmettes/DynAdjust/blob/9488bee07765690afb321df46fb5f70c511d4058/.gitignore) in order for git to ignore CMake generated files. That is, git will no longer track `CMakeCache.txt`, `Makefile`, etc.  (some more [info on .gitignore](https://www.atlassian.com/git/tutorials/saving-changes/gitignore))

I think it's a good idea to ignore these, to avoid the potential that someone might accidentally commit one and then will get CMakeCache conflicts. Also, I like being able to look at `$ git status` and see what I changed without sorting through these generated files.

For example, without `.gitignore`:

```
$  git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	dynadjust/CMakeCache.txt
	dynadjust/CMakeFiles/
	dynadjust/Makefile
	dynadjust/build-gcc/
	dynadjust/cmake_install.cmake
	dynadjust/dynadjust/dnaadjust/CMakeFiles/
	dynadjust/dynadjust/dnaadjust/Makefile
	dynadjust/dynadjust/dnaadjust/cmake_install.cmake
	dynadjust/dynadjust/dnaadjust/libdnaadjust.so
	dynadjust/dynadjust/dnaadjustwrapper/CMakeFiles/
	dynadjust/dynadjust/dnaadjustwrapper/Makefile
	dynadjust/dynadjust/dnaadjustwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnaadjustwrapper/dnaadjust
	dynadjust/dynadjust/dnageoid/CMakeFiles/
	dynadjust/dynadjust/dnageoid/Makefile
	dynadjust/dynadjust/dnageoid/cmake_install.cmake
	dynadjust/dynadjust/dnageoid/libdnageoid.so
	dynadjust/dynadjust/dnageoidwrapper/CMakeFiles/
	dynadjust/dynadjust/dnageoidwrapper/Makefile
	dynadjust/dynadjust/dnageoidwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnageoidwrapper/dnageoid
	dynadjust/dynadjust/dnaimport/CMakeFiles/
	dynadjust/dynadjust/dnaimport/Makefile
	dynadjust/dynadjust/dnaimport/cmake_install.cmake
	dynadjust/dynadjust/dnaimport/libdnaimport.so
	dynadjust/dynadjust/dnaimportwrapper/CMakeFiles/
	dynadjust/dynadjust/dnaimportwrapper/Makefile
	dynadjust/dynadjust/dnaimportwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnaimportwrapper/dnaimport
	dynadjust/dynadjust/dnaplot/CMakeFiles/
	dynadjust/dynadjust/dnaplot/Makefile
	dynadjust/dynadjust/dnaplot/cmake_install.cmake
	dynadjust/dynadjust/dnaplot/libdnaplot.so
	dynadjust/dynadjust/dnaplotwrapper/CMakeFiles/
	dynadjust/dynadjust/dnaplotwrapper/Makefile
	dynadjust/dynadjust/dnaplotwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnaplotwrapper/dnaplot
	dynadjust/dynadjust/dnareftran/CMakeFiles/
	dynadjust/dynadjust/dnareftran/Makefile
	dynadjust/dynadjust/dnareftran/cmake_install.cmake
	dynadjust/dynadjust/dnareftran/libdnareftran.so
	dynadjust/dynadjust/dnareftranwrapper/CMakeFiles/
	dynadjust/dynadjust/dnareftranwrapper/Makefile
	dynadjust/dynadjust/dnareftranwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnareftranwrapper/dnareftran
	dynadjust/dynadjust/dnasegment/CMakeFiles/
	dynadjust/dynadjust/dnasegment/Makefile
	dynadjust/dynadjust/dnasegment/cmake_install.cmake
	dynadjust/dynadjust/dnasegment/libdnasegment.so
	dynadjust/dynadjust/dnasegmentwrapper/CMakeFiles/
	dynadjust/dynadjust/dnasegmentwrapper/Makefile
	dynadjust/dynadjust/dnasegmentwrapper/cmake_install.cmake
	dynadjust/dynadjust/dnasegmentwrapper/dnasegment
	dynadjust/dynadjust/dynadjust/CMakeFiles/
	dynadjust/dynadjust/dynadjust/Makefile
	dynadjust/dynadjust/dynadjust/cmake_install.cmake
	dynadjust/dynadjust/dynadjust/dynadjust
```

After `.gitignore`, it will be slimmed down to:

```
$ git status
```

Some more examples of files which might be worth keeping out of git at some point:
- https://github.com/github/gitignore/blob/master/CMake.gitignore
- https://github.com/github/gitignore/blob/master/C++.gitignore

Note: one potential issue with ignoring something like `Makefile` is that genuine cases where someone wants to include such a file will be prohibited by `.gitignore`. In that case, it won't be able to add or commit that file.