### PR TITLE
Negative (western hemisphere) longitude defect

### DIFF
--- a/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
+++ b/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
@@ -1200,8 +1200,11 @@ int main(int argc, char* argv[])
 		cout << setw(PRINT_VAR_PAD) << left << "  Binary measurement output file: " << p.i.bms_file << endl;
 		
 		if (!p.i.reference_frame.empty())
-			cout << setw(PRINT_VAR_PAD) << left << "  Default reference frame" << p.i.reference_frame << endl;
+			cout << setw(PRINT_VAR_PAD) << left << "  Default reference frame:" << p.i.reference_frame << endl;
 	
+		if (p.i.override_input_rfame)
+			cout << setw(PRINT_VAR_PAD) << left << "  Override input file ref frame:" << yesno_string(p.i.override_input_rfame) << endl;
+
 		if (p.i.export_dynaml)
 		{
 			if (p.i.export_single_xml_file)

--- a/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.vcxproj
+++ b/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.vcxproj
@@ -77,7 +77,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);C:\Program Files (x86)\CodeSynthesis XSD 4.0\include;$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(BoostLibDir);$(TBBLibDir)\vc_mt;$(OmpLibDir);$(MKLLibDir);$(LibraryPath)</LibraryPath>
     <TargetName>import</TargetName>
     <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
@@ -85,7 +85,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);C:\Program Files (x86)\CodeSynthesis XSD 4.0\include;$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(BoostLibDir);$(TBBLibDir)\vc_mt;$(OmpLibDir);$(MKLLibDir);$(LibraryPath)</LibraryPath>
     <TargetName>import</TargetName>
     <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
@@ -93,7 +93,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);C:\Program Files (x86)\CodeSynthesis XSD 4.0\include;$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(BoostLibDir);$(TBBLibDir)\vc_mt;$(OmpLibDir);$(MKLLibDir);$(LibraryPath)</LibraryPath>
     <TargetName>import</TargetName>
     <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>
@@ -101,7 +101,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)dynadjust\dnaimport;$(SolutionDir);$(BoostIncludeDir);C:\Program Files (x86)\CodeSynthesis XSD 4.0\include;$(MKLIncludeDir);$(TBBIncludeDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(BoostLibDir);$(TBBLibDir)\vc_mt;$(OmpLibDir);$(MKLLibDir);$(LibraryPath)</LibraryPath>
     <TargetName>import</TargetName>
     <OutDir>$(SolutionDir)bin\$(Configuration)\$(Platform)\</OutDir>

--- a/dynadjust/include/config/dnaconsts.hpp
+++ b/dynadjust/include/config/dnaconsts.hpp
@@ -40,10 +40,10 @@ const UINT16 GEOLAB_COUT(2);
 const UINT16 NEWGAN_COUT(3);
 const UINT16 GMT_OUT(4);
 
-const char* const DEFAULT_DATUM(GDA94_s);
-const char* const DEFAULT_EPSG_S(GDA94_c);
-const UINT32 DEFAULT_EPSG_U(GDA94_i);
-const char* const DEFAULT_EPOCH(GDA94_epoch);
+const char* const DEFAULT_DATUM(GDA2020_s);
+const char* const DEFAULT_EPSG_S(GDA2020_c);
+const UINT32 DEFAULT_EPSG_U(GDA2020_i);
+const char* const DEFAULT_EPOCH(GDA2020_epoch);
 
 const char* const XYZ_type("XYZ");
 const char* const LLh_type("LLh");

--- a/dynadjust/include/config/dnaprojectfile.cpp
+++ b/dynadjust/include/config/dnaprojectfile.cpp
@@ -667,6 +667,18 @@ void CDnaProjectFile::LoadSettingImport(const settingMode mSetting, const string
 			return;			
 		settings_.i.input_files.push_back(formPath<string>(settings_.g.input_folder, val));
 	}
+	else if (iequals(var, REFERENCE_FRAME))
+	{
+		if (val.empty())
+			return;
+		settings_.i.reference_frame = val;
+	}
+	else if (iequals(var, OVERRIDE_INPUT_FRAME))
+	{
+		if (val.empty())
+			return;
+		settings_.i.override_input_rfame = yesno_uint<UINT16, string>(val);;
+	}
 	else if (iequals(var, IMPORT_GEO_FILE))
 	{
 		if (val.empty())
@@ -1637,9 +1649,16 @@ void CDnaProjectFile::PrintProjectFile()
 			PrintRecord(dnaproj_file, IMPORT_FILE, leafStr<string>(file.c_str()));
 	});
 
+	// geoid file
 	PrintRecord(dnaproj_file, IMPORT_GEO_FILE, 
-		(settings_.i.geo_file.empty() ? " " : leafStr<string>(settings_.i.geo_file)));								// geoid file
+		(settings_.i.geo_file.empty() ? " " : leafStr<string>(settings_.i.geo_file)));
 
+	// reference frame settings
+	PrintRecord(dnaproj_file, REFERENCE_FRAME, settings_.i.reference_frame);
+	PrintRecord(dnaproj_file, OVERRIDE_INPUT_FRAME, 
+		yesno_string(settings_.i.override_input_rfame));
+
+	// data screening
 	PrintRecord(dnaproj_file, BOUNDING_BOX, settings_.i.bounding_box);
 	PrintRecord(dnaproj_file, GET_MSRS_TRANSCENDING_BOX, 
 		yesno_string(settings_.i.include_transcending_msrs));
@@ -1679,12 +1698,14 @@ void CDnaProjectFile::PrintProjectFile()
 	PrintRecord(dnaproj_file, TEST_INTEGRITY,
 		yesno_string(settings_.i.test_integrity));						
 	
+	// GNSS variance matrix scaling
 	PrintRecord(dnaproj_file, VSCALE, settings_.i.vscale);				
 	PrintRecord(dnaproj_file, PSCALE, settings_.i.pscale);				
 	PrintRecord(dnaproj_file, LSCALE, settings_.i.lscale);				
 	PrintRecord(dnaproj_file, HSCALE, settings_.i.hscale);				
 	PrintRecord(dnaproj_file, SCALAR_FILE, leafStr<string>(settings_.i.scalar_file));
 
+	// export options
 	PrintRecord(dnaproj_file, EXPORT_XML_FILES, 
 		yesno_string(settings_.i.export_dynaml));						// Create DynaML output file
 	PrintRecord(dnaproj_file, EXPORT_SINGLE_XML_FILE, 

--- a/dynadjust/include/functions/dnatemplategeodesyfuncs.hpp
+++ b/dynadjust/include/functions/dnatemplategeodesyfuncs.hpp
@@ -217,8 +217,11 @@ void CartToGeo(const T& X, const T& Y, const T& Z,
 	else if (x < 0.0 && y < 0.0)
 		*longitude = -(PI - *longitude);
 
-	if (*longitude < 0.)
-		*longitude += TWO_PI;
+	// The following line causes an issue for west longitudes, which by nature are negative!
+	// Not sure why this was introduced.  Removing the conditional absolute has no adverse impact on
+	// positions which are located in the eastern hemisphere,
+	//if (*longitude < 0.)
+	//	*longitude += TWO_PI;
 	
 	// Compute height
 	*height = sqrt(((p - p_E) * (p - p_E)) + ((z - Z_E) * (z - Z_E)));


### PR DESCRIPTION
For networks in the western hemisphere, the introduction of a Q (longitude) measurement causes the adjustment to fail.  By nature, a Q measurement in the western hemisphere will be a negative longitude. When DynAdjust computes the 'measured minus computed' vector from the adjusted coordinates and the original measurement, the computed longitude is incorrectly converted to a positive value with the addition of 360 degrees.  This fix addresses an incorrect addition of 360 degrees,