### PR TITLE
Terr2140/add dbid backsight

### DIFF
--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -11195,7 +11195,17 @@ void dna_adjust::PrintAdjMeasurements_D(it_vmsr_t& _it_msr)
 	if (_it_msr->ignore)
 		ignoreFlag = "*";
 
-	adj_file << setw(PAD3) << left << ignoreFlag << setw(PAD2) << left << " " << endl;
+  adj_file << setw(PAD3) << left << ignoreFlag << setw(PAD2) << left << " ";
+  
+  if (projectSettings_.o._database_ids)
+  {
+    // Measured + Computed + Correction + Measured + Adjusted + Residual + N Stat + T Stat + Pelzer + Pre Adj Corr + Outlier
+    UINT32 b(MSR + MSR + CORR + PREC + PREC + PREC + STAT + REL + PACORR + OUTLIER + STDDEV);
+    if (projectSettings_.o._adj_msr_tstat)
+       b += STAT;
+    adj_file << setw(b) << right << _it_dbid->msr_id;
+  }
+  adj_file << endl;
 
 	UINT32 a, angle_count(_it_msr->vectorCount1 - 1);
 

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -11195,17 +11195,17 @@ void dna_adjust::PrintAdjMeasurements_D(it_vmsr_t& _it_msr)
 	if (_it_msr->ignore)
 		ignoreFlag = "*";
 
-  adj_file << setw(PAD3) << left << ignoreFlag << setw(PAD2) << left << " ";
-  
-  if (projectSettings_.o._database_ids)
-  {
-    // Measured + Computed + Correction + Measured + Adjusted + Residual + N Stat + T Stat + Pelzer + Pre Adj Corr + Outlier
-    UINT32 b(MSR + MSR + CORR + PREC + PREC + PREC + STAT + REL + PACORR + OUTLIER + STDDEV);
-    if (projectSettings_.o._adj_msr_tstat)
-       b += STAT;
-    adj_file << setw(b) << right << _it_dbid->msr_id;
-  }
-  adj_file << endl;
+	adj_file << setw(PAD3) << left << ignoreFlag << setw(PAD2) << left << " ";
+	
+	if (projectSettings_.o._database_ids)
+	{
+		// Measured + Computed + Correction + Measured + Adjusted + Residual + N Stat + T Stat + Pelzer + Pre Adj Corr + Outlier
+		UINT32 b(MSR + MSR + CORR + PREC + PREC + PREC + STAT + REL + PACORR + OUTLIER + STDDEV);
+		if (projectSettings_.o._adj_msr_tstat)
+			 b += STAT;
+		adj_file << setw(b) << right << _it_dbid->msr_id;
+	}
+	adj_file << endl;
 
 	UINT32 a, angle_count(_it_msr->vectorCount1 - 1);
 


### PR DESCRIPTION
Update the adjustment report to include the DBID of direction-set backsight lines.

![image](https://user-images.githubusercontent.com/4838139/82262233-5d7c1f80-9915-11ea-9000-dc55ac83aa03.png)

1. This makes it consistent with how other rows are written.
2. Allows software that reads these files know the source of backsight lines. 