### PR TITLE
Fix to (repeat) computation of ignored direction measurements

### DIFF
--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -10645,6 +10645,8 @@ void dna_adjust::UpdateIgnoredMeasurements_D(pit_vmsr_t _it_msr, const UINT32& b
 				// Derive the variance of the angle
 				(*_it_msr)->scale2 = previousVariance + (*_it_msr)->term2;
 			}
+			else
+				it_angle->preAdjMeas = (*_it_msr)->scale1;
 			
 			UpdateIgnoredMeasurements_A(&it_angle, block, estimatedStations, storeOriginalMeasurement);
 						


### PR DESCRIPTION
This change ensures a repeated adjustment (undertaken without import, segment, geoid, etc.) correctly computes adjusted msr and msr corr values for ignored direction measurements.