### PR TITLE
Minor changes to prevent column overrun in fixed-width output files

### DIFF
--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.0)
 
 project (dynadjust)
 
-set (DYNADJUST_VERSION "1.0.3")
+set (DYNADJUST_VERSION "1.1.0")
 
 if (BUILD_TESTING)
     enable_testing()

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
@@ -360,6 +360,7 @@ public:
 	bool					isCombining_;
 	bool					forward_;
 	bool					isFirstTimeAdjustment_;
+	bool					isAdjustmentQuestionable_;
 	
 	UINT32					blockCount_;
 	UINT32					currentBlock_;
@@ -967,9 +968,6 @@ private:
 	// queue to handle notification of messages for each iteration
 	concurrent_queue<UINT32> iterationQueue_;
 
-	// flag to tell if users have cancelled running dynajust
-	std::atomic<bool>				isCancelled_;
-
 #ifdef MULTI_THREAD_ADJUST
 	// ----------------------------------------------
 	// Adjustment matrices for multi-threaded phased adjustment
@@ -992,6 +990,10 @@ private:
 	bool					databaseIDsLoaded_;
 
 	void LoadDatabaseId();
+
+	// flag to tell if users have cancelled running dynajust
+	std::atomic<bool>				isCancelled_;
+
 };
 
 }	// namespace networkadjust

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
@@ -360,6 +360,7 @@ public:
 	bool					isCombining_;
 	bool					forward_;
 	bool					isFirstTimeAdjustment_;
+	bool					isIterationComplete_;
 	bool					isAdjustmentQuestionable_;
 	
 	UINT32					blockCount_;

--- a/dynadjust/include/functions/dnastrmanipfuncs.hpp
+++ b/dynadjust/include/functions/dnastrmanipfuncs.hpp
@@ -194,7 +194,7 @@ string StringFromTW(const T& t, const U& width, const U& precision=0)
 
 	// Assume number at precision prints within width
 	ss << setw(width) << fixed << right << setprecision(precision) << t;
-	int trim = trimstr(ss.str()).length() - width;
+	int trim = (int)trimstr(ss.str()).length() - width;
 
 	// Formatted string length is less than or equal to the fixed width
 	if (trim <= 0)

--- a/dynadjust/include/functions/dnastrmanipfuncs.hpp
+++ b/dynadjust/include/functions/dnastrmanipfuncs.hpp
@@ -187,6 +187,57 @@ T trimstrright(const T& Src) {
 	return trimstrright_(Src, static_cast<T>(" \r\n"));
 }
 
+template <class T, class U>
+string StringFromTW(const T& t, const U& width, const U& precision=0)
+{
+	stringstream ss;
+
+	// Assume number at precision prints within width
+	ss << setw(width) << fixed << right << setprecision(precision) << t;
+	int trim = trimstr(ss.str()).length() - width;
+
+	// Formatted string length is less than or equal to the fixed width
+	if (trim <= 0)
+		return ss.str();
+
+	ss.str("");
+
+	// Formatted string length exceeds fixed width by trim.
+	// Use scientific notation if the overflow is 
+	// greater than the precision
+	if (trim > 0)
+	{
+		// scientific notation requires 6 or 5
+		// characters (e.g. -1e+00 or 1e+00), not
+		// including the fractional part
+		if (width < (t < 0. ? 6 : 5))
+		{
+			// insufficient space for scientific notation!!!
+			ss << setw(width) << string(width, '#');
+			return ss.str();
+		}
+		
+		int prec1 = width - (t < 0. ? 6 : 5);
+		// if precision is required, an extra space is needed for
+		// the decimal point, so reduce by one.
+		if (prec1 > 0)
+			prec1--;
+		
+		int prec = min<int>(precision, prec1);
+		
+		ss << setw(width) << scientific << right << setprecision(prec) << t;
+	}
+	else
+	{
+		int prec = precision - trim;
+		if (prec < 0)
+			prec = 0;
+		ss << setw(width) << fixed << right << setprecision(prec) << t;
+	}
+
+	return ss.str();
+}
+
 template <class T>
 string StringFromT(const T& t, const int& precision=-1)
 {


### PR DESCRIPTION
This pull request fixes #78 by formatting the output of larger-than-expected values, such that they fit within the respective column widths in .adj and .cor files.  As the new print function (`StringFromTW`) is adaptive and time consuming, this formatting is performed when an adjustment appears to be questionable or troublesome (i.e. very large measurement corrections or n-stat values).