### PR TITLE
Extend discontinuity renaming functionality, bug fix and other enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ dynadjust/bin/
 *.db-wal
 *.user
 /.idea/
-.vscode/launch.json
+.vscode/*
 
 # readme and other files not requiring external contribution
 README.md

--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -229,6 +229,9 @@ if (BUILD_TESTING)
     add_test (NAME ref-itrf-pmm-05 COMMAND $<TARGET_FILE:dnaimportwrapper> -n apr -r itrf2008 ${CMAKE_SOURCE_DIR}/../sampleData/apr.ITRF2008.04.06.2020.stn ${CMAKE_SOURCE_DIR}/../sampleData/apr.ITRF2008.04.06.2020.msr)
     add_test (NAME ref-itrf-pmm-06 COMMAND $<TARGET_FILE:dnareftranwrapper> apr -r itrf2008 -e 01.01.2021 --export-dna --verb 2 --plate-model-option 1 -b ${CMAKE_SOURCE_DIR}/../sampleData/MORVEL56_plates.dig -m ${CMAKE_SOURCE_DIR}/../sampleData/NNR-MORVEL56_poles.dat)
     add_test (NAME ref-itrf-pmm-07 COMMAND bash -c "diff <(tail -n +6 apr.ITRF2008.01.01.2021.stn) <(tail -n +4 ${CMAKE_SOURCE_DIR}/../sampleData/apr.ITRF2008.01.01.2021.stn.expected)")
+
+    add_test (NAME imp-discont-01 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx)
+    add_test (NAME imp-discont-02 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx --split-gnss --include-stn "ALIC" --export-dna)
     
     # set execution dependencies (the execution of tests must be sequential)
     set_tests_properties(

--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -233,6 +233,8 @@ if (BUILD_TESTING)
     add_test (NAME imp-discont-01 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx)
     add_test (NAME imp-discont-02 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx --split-gnss --include-stn "ALIC" --export-dna)
     
+    add_test (NAME imp-m2s-sort-01 COMMAND $<TARGET_FILE:dnaimportwrapper> -n gnss ${CMAKE_SOURCE_DIR}/../sampleData/gnss-network.stn ${CMAKE_SOURCE_DIR}/../sampleData/gnss-network.msr --output-msr-to-stn --sort-msr-to-stn-field 1 -r GDA94) 
+
     # set execution dependencies (the execution of tests must be sequential)
     set_tests_properties(
         import-gnss-network geoid-gnss-network adjust-gnss-network

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -9641,9 +9641,9 @@ void dna_adjust::PrintAdjStation(ostream& os,
 			StringFromTW(sqrt(var_local.get(2, 2)), STDDEV, PRECISION_MTR_STN);
 	else
 		os <<
-			StringFromT(sqrt(var_local.get(0, 0)), PRECISION_MTR_STN) <<
-			StringFromT(sqrt(var_local.get(1, 1)), PRECISION_MTR_STN) <<
-			StringFromT(sqrt(var_local.get(2, 2)), PRECISION_MTR_STN);
+			setw(STDDEV) << right << StringFromT(sqrt(var_local.get(0, 0)), PRECISION_MTR_STN) <<
+			setw(STDDEV) << right << StringFromT(sqrt(var_local.get(1, 1)), PRECISION_MTR_STN) <<
+			setw(STDDEV) << right << StringFromT(sqrt(var_local.get(2, 2)), PRECISION_MTR_STN);
 
 	if (projectSettings_.o._stn_corr)
 	{

--- a/dynadjust/dynadjust/dnaimport/dnainterop.cpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.cpp
@@ -156,6 +156,46 @@ void dna_import::BuildExtractStationsList(const string& stnList, pvstring vstnLi
 		ss << "BuildExtractStationsList(): An error was encountered when parsing " << stnList << "." << endl;
 		SignalExceptionParse(ss.str(), 0);
 	}
+
+	// Have discontinuities been applied?
+	if (!projectSettings_.i.apply_discontinuities)
+		return;
+
+	if (stn_renamed_.empty())
+		return;
+
+	it_string_pair _it_discont_ren;
+
+	_it_vstr _it_stn;
+	string station_name;
+	vstring renamed_stations;
+
+	// loop through all station names in vstnList
+	for (_it_stn = vstnList->begin();
+		_it_stn != vstnList->end();
+		_it_stn++)
+	{
+		station_name = *_it_stn;
+		
+		_it_discont_ren = stn_renamed_.begin();
+
+		// Advance through _it_discont_ren for all occurrences of station_name
+		while ((_it_discont_ren = lower_bound(_it_discont_ren, stn_renamed_.end(), 
+			station_name, ComparePairFirst<string>())) != stn_renamed_.end())
+		{
+			// found a station that has been renamed.			
+			// add the discontinuity name to the list
+			renamed_stations.push_back(_it_discont_ren->second);
+			_it_discont_ren++;
+		}
+	}
+
+	// Add discontinuity sites and remove duplicates
+	if (!renamed_stations.empty())
+	{
+		vstnList->insert(vstnList->end(), renamed_stations.begin(), renamed_stations.end());
+		strip_duplicates(vstnList);
+	}
 }
 	
 
@@ -719,25 +759,32 @@ void dna_import::ParseDiscontinuities(const string& fileName)
 	discont_file.close();
 }
 	
+// Station names in SINEX files are automatically renamed to account for discontinuities and added
+// to vStations.  For non SINEX files, any renamed stations are tracked in stn_renamed_.  After
+// all files have been loaded, this function is called to (1) find any discontinuity stations not in the 
+// station list and (2) add a duplicate for it, renamed to the respective discontinuity site name.
 void dna_import::AddDiscontinuityStations(vdnaStnPtr* vStations)
 {
 	_it_vdnastnptr _it_stn(vStations->begin());
-	it_string_pair stn_renames_it;
+	it_string_pair stn_renames_it(stn_renamed_.begin());
 
 	dnaStnPtr stn_ptr;
 	string stationName;
 	
 	UINT32 i, station_count(static_cast<UINT32>(vStations->size()));
 	UINT32 station_index(station_count);
+
+	sort(vStations->begin(), vStations->end(), CompareStationName<dnaStnPtr>());
 	
 	for (i=0; i<station_count; ++i)
 	{
 		stationName = vStations->at(i)->GetName();
-
+	
 		// For each occurrence of stationName in stn_renamed_, create a clone and add it to 
-		// vStations so that the measurement stations renamed by ApplyDiscontinuitiesMeasurements
-		// are supported by corresponding stations
-		while ((stn_renames_it = binary_search_index_pair(stn_renamed_.begin(), stn_renamed_.end(), stationName)) != stn_renamed_.end())
+		// vStations so that the measurement stations in non SINEX files that are
+		// renamed by ApplyDiscontinuitiesMeasurements (via TrackDiscontinuitySite) are 
+		// supported by corresponding stations.
+		while ((stn_renames_it = binary_search_index_pair(stn_renames_it, stn_renamed_.end(), stationName)) != stn_renamed_.end())
 		{
 			// If a sinex file has been loaded and stationName exists in the sinex file, stn_renames_it->second may 
 			// already exist in vStations.  In this case, the following code will add a duplicate station.
@@ -752,15 +799,13 @@ void dna_import::AddDiscontinuityStations(vdnaStnPtr* vStations)
 			stn_ptr->SetfileOrder(++station_index);
 			vStations->push_back(stn_ptr);
 			
-			if (!stn_renamed_.empty())
-				stn_renamed_.erase(stn_renames_it);
+			stn_renames_it++;
 		}
 
-		if (stn_renamed_.empty())
-			break;
+		stn_renames_it = stn_renamed_.begin();
 	}
 
-	// Removde duplicates which may have been added through the above process
+	// Remove duplicates which may have been added through the above process
 	sort(vStations->begin(), vStations->end(), CompareStationName<dnaStnPtr>());
 	_it_vdnastnptr _it_stn_newend = unique(vStations->begin(), vStations->end(), EqualStationName<dnaStnPtr>());
 	if (_it_stn_newend != vStations->end())
@@ -771,11 +816,6 @@ void dna_import::AddDiscontinuityStations(vdnaStnPtr* vStations)
 
 void dna_import::ApplyDiscontinuities(vdnaStnPtr* vStations, vdnaMsrPtr* vMeasurements, project_settings* p)
 {
-#ifndef _MSDEBUG
-	// return on release
-	return;
-#endif
-
 	if (stn_discontinuities_.empty())
 		return;
 
@@ -786,11 +826,16 @@ void dna_import::ApplyDiscontinuities(vdnaStnPtr* vStations, vdnaMsrPtr* vMeasur
 		m_discontsSortedbyName = true;
 	}
 
-	// There isn't any need to apply discontinuities to a station file, since those
-	// stations will be introduced via the process of handling a discontinuity file.
-	// DynAdjust should load the stations as normal. If a station becomes renamed
-	// through the process of applying discontinuities to measurements, then it will
-	// be flagged as unused (since it won't be found in the measurements).
+	// If the only input file is a SINEX file, there isn't any need to apply discontinuities 
+	// to a station file, since those stations will be introduced via the process of 
+	// handling a discontinuity file. 
+	// However, if other station and measurement file types are loaded, there may be a case 
+	// where station discontinuities exist but have not been accounted for at this point.  
+	// For this purpose, a call to ApplyDiscontinuitiesStations will be made after all files 
+	// have been imported.
+	// If a station becomes renamed through the process of applying discontinuities to 
+	// measurements, then it will be flagged as unused (since it won't be found in the 
+	// measurements).
 
 	if (!vMeasurements->empty())
 		ApplyDiscontinuitiesMeasurements(vMeasurements, p);
@@ -805,9 +850,10 @@ void dna_import::TrackDiscontinuitySite(const string& site, const string& site_r
 	}
 }
 	
+
 // This function renames stations in each measurement based on a discontinuity file
 // NOTE: A fundamental prerequisite for the proper renaming of discontinuity sites
-// in this function is a valid epoch for each measurement!s
+// in this function is a valid epoch for each measurement!
 void dna_import::ApplyDiscontinuitiesMeasurements(vdnaMsrPtr* vMeasurements, project_settings* p)
 {
 	_it_vdiscontinuity_tuple _it_discont(stn_discontinuities_.begin());

--- a/dynadjust/dynadjust/dnaimport/dnainterop.cpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.cpp
@@ -1480,6 +1480,12 @@ void dna_import::ParseDNASTN(vdnaStnPtr* vStations, PUINT32 stnCount, string* su
 			catch (...) {
 				switch (stn_ptr->GetMyCoordTypeC())
 				{
+				case LLh_type_i:
+				case LLH_type_i:
+				case ENU_type_i:
+				case AED_type_i:
+				case XYZ_type_i:
+					break;
 				case UTM_type_i:	// Hemisphere and zone is only essential for UTM types
 					stringstream ss;
 					ss << "ParseDNASTN(): Could not extract station hemisphere and zone from the record:  " << endl << "    " << sBuf << endl;
@@ -3112,7 +3118,7 @@ void dna_import::ExtractStnsAndAssociatedMsrs(const string& stnListInclude, cons
 	// backup station vector
 	vdnaStnPtr bvStations = *vStations;
 
-	const string *stnListIn, *stnListEx;
+	const string *stnListIn;
 
 	vstring vIncludedStns;
 	pvstring pvStnsIn, pvStnsEx;
@@ -3123,7 +3129,6 @@ void dna_import::ExtractStnsAndAssociatedMsrs(const string& stnListInclude, cons
 		pvStnsIn = &vIncludedStns;
 		pvStnsEx = vExcludedStns;		
 		stnListIn = &stnListInclude; 
-		stnListEx = &stnListExclude;
 	}
 	// Has the user provided a list of stations to exclude?
 	else if (!stnListExclude.empty()) 
@@ -3131,7 +3136,6 @@ void dna_import::ExtractStnsAndAssociatedMsrs(const string& stnListInclude, cons
 		pvStnsIn = vExcludedStns;
 		pvStnsEx = &vIncludedStns;
 		stnListIn = &stnListExclude; 
-		stnListEx = &stnListInclude;
 	}
 	else
 	{

--- a/dynadjust/dynadjust/dnaimport/dnainterop.hpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.hpp
@@ -135,7 +135,6 @@ public:
 	void RenameStations(vdnaStnPtr* vStations, vdnaMsrPtr* vMeasurements, project_settings* p);
 	void ApplyDiscontinuities(vdnaStnPtr* vStations, vdnaMsrPtr* vMeasurements, project_settings* p);
 	void TrackDiscontinuitySite(const string& site, const string& site_renamed);
-	void ApplyDiscontinuitiesStations(vdnaStnPtr* vStations, project_settings* p);
 	void ApplyDiscontinuitiesMeasurements(vdnaMsrPtr* vMeasurements, project_settings* p);
 
 	void ApplyDiscontinuitiesMeasurements_GX(vector<CDnaGpsBaseline>* vGpsBaselines);

--- a/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
+++ b/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
@@ -550,6 +550,7 @@ void ExportStationsandMeasurements(dna_import* parserDynaML, const project_setti
 				cout << "Done." << endl;
 				cout.flush();
 			}
+			*imp_file << "Done." << endl;
 		}
 		else
 		{
@@ -584,6 +585,7 @@ void ExportStationsandMeasurements(dna_import* parserDynaML, const project_setti
 				cout << "Done." << endl;
 				cout.flush();
 			}
+			*imp_file << "Done." << endl;
 		}		
 	}
 
@@ -1442,6 +1444,18 @@ int main(int argc, char* argv[])
 		}
 	}
 
+	/////////////////////////////////////////////////////////////////////////
+	// Add discontinuity sites to vStations
+	//
+	// WARNING: If discontinuity sites are present in the renaming file, and
+	// the renaming file changes the name from the four-character id in the 
+	// discontinuity file to another name, this function call will not work
+	// properly. Hence, sites in the discontinuity file must be consistently
+	// named in the station and measurement files and not renamed to another
+	// name.
+	if (p.i.apply_discontinuities && !vstationsTotal.empty())
+		parserDynaML.AddDiscontinuityStations(&vstationsTotal);
+
 	UINT32 stn;
 
 	// Extract user-defined stations and all connected measurements
@@ -1861,24 +1875,11 @@ int main(int argc, char* argv[])
 			imp_file.close();
 			return EXIT_FAILURE;
 		}		
-	
-		/////////////////////////////////////////////////////////////////////////
-		// Add discontinuity sites to vStations
-		//
-		// WARNING: If discontinuity sites are present in the renaming file, and
-		// the renaming file changes the name from the four-character id in the 
-		// discontinuity file to another name, this function call will not work
-		// properly. Hence, sites in the discontinuity file must be consistently
-		// named in the station and measurement files and not renamed to another
-		// name.
-		if (p.i.apply_discontinuities && stnCount > 0)
-			parserDynaML.AddDiscontinuityStations(&vstationsTotal);
 
 		/////////////////////////////////////////////////////////////////
 		// Now commence sorting and mapping
 		// 1. Sort stations
-		// 2. Add new discontinuity sites
-		// 3. Create station map
+		// 2. Create station map
 		try {
 			if (!p.g.quiet)
 			{
@@ -2218,8 +2219,7 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	// Create ASL and AML files
-	// Export to text if required
+	// Export ASL and AML to text if required
 	if (measurements_mapped) 
 	{
 		try {

--- a/dynadjust/include/functions/dnatemplatefuncs.hpp
+++ b/dynadjust/include/functions/dnatemplatefuncs.hpp
@@ -959,15 +959,28 @@ private:
 
 
 // S = CDnaStation
-template<typename S>
+template<typename S, typename T>
 class CompareStnName_CDnaStn
 {
 public:
 	bool operator()(const boost::shared_ptr<S> lhs, const boost::shared_ptr<S> rhs) {
 		if (lhs.get()->GetName() == rhs.get()->GetName())
 			return (lhs.get()->GetfileOrder() < rhs.get()->GetfileOrder());
-		return (lhs.get()->GetName() < rhs.get()->GetName());
-		
+		return keyLess(lhs.get()->GetName(), rhs.get()->GetName());
+	}
+
+	bool operator()(const T lhs, const boost::shared_ptr<S> rhs) {
+		return keyLess(lhs, rhs.get()->GetName());
+	}
+
+	bool operator()(const boost::shared_ptr<S> lhs, const T rhs) {
+		return keyLess(lhs.get()->GetName(), rhs);
+	}
+
+private:
+	// the "real" comparison function
+	bool keyLess(const T& k1, const T& k2) const {
+		return k1 < k2;
 	}
 };
 

--- a/dynadjust/include/io/dnaiosnx.hpp
+++ b/dynadjust/include/io/dnaiosnx.hpp
@@ -252,7 +252,7 @@ class dna_io_snx : public dna_io_base
 public:
 	dna_io_snx(void) 
 	: blockCount_(0), block_(0), measurementParams_(0), unknownParams_(0)
-	, sigmaZero_(0.), uniqueStationCount_(0)
+	, sigmaZero_(0.), blockStationsMap_(0), uniqueStationCount_(0)
 	, containsVelocities_(false), containsDiscontinuities_(false), applyDiscontinuities_(false)
 	, siteIDsRead_(false), solutionEpochsRead_(false) {
 	}

--- a/dynadjust/include/measurement_types/dnastation.hpp
+++ b/dynadjust/include/measurement_types/dnastation.hpp
@@ -73,6 +73,7 @@ typedef boost::shared_ptr<CDnaStation> dnaStnPtr;
 typedef vector<dnaStnPtr> vdnaStnPtr;		// vector of dnaStnPtr
 typedef vdnaStnPtr::iterator _it_vdnastnptr;
 typedef vdnaStnPtr::const_iterator _it_vdnastnptr_const;
+typedef pair<_it_vdnastnptr, _it_vdnastnptr> it_pair_dnastnptr;
 
 typedef vector<CAStationList> vASL, *pvASL;
 typedef vASL::iterator _it_vasl;

--- a/sampleData/disconts20201205.snx
+++ b/sampleData/disconts20201205.snx
@@ -1,0 +1,4763 @@
++SOLUTION/DISCONTINUITY
+ ABPO  A    2 P 18:135:27000 00:000:00000 P - 
+ ABPO  A    1 P 00:000:00000 00:000:00000 V - 
+ ADE1  A    1 P 00:000:00000 00:000:00000 P - 
+ ADE1  A    1 P 00:000:00000 00:000:00000 V - 
+ ADIS  A    1 P 00:000:00000 00:000:00000 P - 
+ ADIS  A    1 P 00:000:00000 00:000:00000 V - 
+ AJAC  A    1 P 00:000:00000 08:331:00000 P - antenna change
+ AJAC  A    2 P 08:331:00000 12:340:32400 P - antenna change
+ AJAC  A    3 P 12:340:32400 20:021:36000 P - antenna change
+ AJAC  A    4 P 20:021:36000 00:000:00000 P - 
+ AJAC  A    1 P 00:000:00000 00:000:00000 V - 
+ ALBH  A    1 P 00:000:00000 94:104:74100 P - antenna change
+ ALBH  A    2 P 94:104:74100 95:011:80100 P - antenna change
+ ALBH  A    3 P 95:011:80100 95:202:69960 P - RF skirt installed around based of antenna
+ ALBH  A    4 P 95:202:69960 03:248:60720 P - antenna change
+ ALBH  A    5 P 03:248:60720 15:258:68400 P - antenna change
+ ALBH  A    6 P 15:258:68400 00:000:00000 P - 
+ ALBH  A    1 P 00:000:00000 00:000:00000 V - 
+ ALGO  A    1 P 00:000:00000 94:047:69180 P - antenna change
+ ALGO  A    2 P 94:047:69180 94:139:00000 P - antenna change
+ ALGO  A    3 P 94:139:00000 97:016:00000 P - antenna change
+ ALGO  A    4 P 97:016:00000 12:355:61200 P - antenna change
+ ALGO  A    5 P 12:355:61200 00:000:00000 P - 
+ ALGO  A    1 P 00:000:00000 00:000:00000 V - 
+ ALIC  A    1 P 00:000:00000 11:201:00000 P - antenna change
+ ALIC  A    2 P 11:201:00000 00:000:00000 P - 
+ ALIC  A    1 P 00:000:00000 00:000:00000 V - 
+ ALRT  A    1 P 00:000:00000 00:000:00000 P - 
+ ALRT  A    1 P 00:000:00000 00:000:00000 V - 
+ AMC2  A    1 P 00:000:00000 99:238:00000 P - unknown
+ AMC2  A    2 P 99:238:00000 02:165:60660 P - antenna change
+ AMC2  A    3 P 02:165:60660 07:274:66900 P - antenna change
+ AMC2  A    4 P 07:274:66900 00:000:00000 P - 
+ AMC2  A    1 P 00:000:00000 00:000:00000 V - 
+ AOML  A    1 P 00:000:00000 03:220:00000 P - unknown
+ AOML  A    2 P 03:220:00000 00:000:00000 P - 
+ AOML  A    1 P 00:000:00000 00:000:00000 V - 
+ AREQ  A    1 P 00:000:00000 94:088:00000 P - antenna change
+ AREQ  A    2 P 94:088:00000 94:160:01996 P - EQ M8.2 - La Paz, Bolivia
+ AREQ  A    3 P 94:160:01996 96:317:61184 P - EQ M7.7 - near the coast of central Peru
+ AREQ  A    4 P 96:317:61184 01:174:73994 P - EQ M8.4 - near the coast of southern Peru
+ AREQ  A    5 P 01:174:73994 01:188:34724 P - EQ M7.6 - near the coast of southern Peru
+ AREQ  A    6 P 01:188:34724 07:227:85258 P - EQ M8.0 - near the coast of central Peru
+ AREQ  A    7 P 07:227:85258 14:091:85607 P - EQ M8.2 - 94km NW of Iquique, Chile
+ AREQ  A    8 P 14:091:85607 18:121:05400 P - antenna change
+ AREQ  A    9 P 18:121:05400 00:000:00000 P - 
+ AREQ  A    1 P 00:000:00000 00:000:00000 V - 
+ AREV  A    1 P 00:000:00000 12:034:00000 P - antenna change
+ AREV  A    2 P 12:034:00000 14:091:85607 P - EQ M8.2 - 94km NW of Iquique, Chile
+ AREV  A    3 P 14:091:85607 00:000:00000 P - 
+ AREV  A    1 P 00:000:00000 00:000:00000 V - 
+ ARTU  A    1 P 00:000:00000 00:000:00000 P - 
+ ARTU  A    1 P 00:000:00000 00:000:00000 V - 
+ ASC1  A    1 P 00:000:00000 00:000:00000 P - 
+ ASC1  A    1 P 00:000:00000 00:000:00000 V - 
+ ASCG  A    1 P 00:000:00000 00:000:00000 P - 
+ ASCG  A    1 P 00:000:00000 00:000:00000 V - 
+ AUCK  A    1 P 00:000:00000 01:301:08220 P - antenna change
+ AUCK  A    2 P 01:301:08220 02:336:00000 P - receiver change
+ AUCK  A    3 P 02:336:00000 03:009:08700 P - receiver change
+ AUCK  A    4 P 03:009:08700 05:307:14940 P - antenna change
+ AUCK  A    5 P 05:307:14940 11:059:86340 P - antenna change
+ AUCK  A    6 P 11:059:86340 16:318:39777 P - EQ M7.8 - 54km NNE of Amberley, New Zealand
+ AUCK  A    7 P 16:318:39777 19:296:85380 P - antenna change
+ AUCK  A    8 P 19:296:85380 00:000:00000 P - 
+ AUCK  A    1 P 00:000:00000 00:000:00000 V - 
+ BADG  A    1 P 00:000:00000 05:319:00000 P - antenna change
+ BADG  A    2 P 05:319:00000 06:238:00000 P - antenna change
+ BADG  A    3 P 06:238:00000 07:092:00000 P - antenna change
+ BADG  A    4 P 07:092:00000 10:074:00000 P - antenna change
+ BADG  A    5 P 10:074:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ BADG  A    6 P 11:070:20783 00:000:00000 P - 
+ BADG  A    1 P 00:000:00000 00:000:00000 V - 
+ BAHR  A    1 P 00:000:00000 07:228:00000 P - unknown
+ BAHR  A    2 P 07:228:00000 00:000:00000 P - 
+ BAHR  A    1 P 00:000:00000 00:000:00000 V - 
+ BARH  A    1 P 00:000:00000 07:086:00000 P - antenna change
+ BARH  A    2 P 07:086:00000 19:039:59400 P - antenna change
+ BARH  A    3 P 19:039:59400 00:000:00000 P - 
+ BARH  A    1 P 00:000:00000 00:000:00000 V - 
+ BHR1  A    1 P 00:000:00000 07:228:00000 P - unknown
+ BHR1  A    2 P 07:228:00000 00:000:00000 P - 
+ BHR1  A    1 P 00:000:00000 00:000:00000 V - 
+ BHR4  A    1 P 00:000:00000 00:000:00000 P - 
+ BHR4  A    1 P 00:000:00000 00:000:00000 V - 
+ BILI  A    1 P 00:000:00000 00:000:00000 P - 
+ BILI  A    1 P 00:000:00000 00:000:00000 V - 
+ BJCO  A    1 P 00:000:00000 00:000:00000 P - 
+ BJCO  A    1 P 00:000:00000 00:000:00000 V - 
+ BJFS  A    1 P 00:000:00000 10:142:00000 P - antenna change
+ BJFS  A    2 P 10:142:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ BJFS  A    3 P 11:070:20783 15:330:00000 P - antenna change
+ BJFS  A    4 P 15:330:00000 16:010:00000 P - unknown
+ BJFS  A    5 P 16:010:00000 00:000:00000 P - 
+ BJFS  A    1 P 00:000:00000 00:000:00000 V - 
+ BJNM  A    1 P 00:000:00000 00:000:00000 P - 
+ BJNM  A    1 P 00:000:00000 00:000:00000 V - 
+ BOR1  A    1 P 00:000:00000 99:151:67200 P - antenna change
+ BOR1  A    2 P 99:151:67200 16:279:39600 P - antenna change
+ BOR1  A    3 P 16:279:39600 00:000:00000 P - 
+ BOR1  A    1 P 00:000:00000 00:000:00000 V - 
+ BRAZ  A    1 P 00:000:00000 96:242:00000 P - antenna change
+ BRAZ  A    2 P 96:242:00000 98:118:00000 P - antenna change
+ BRAZ  A    3 P 98:118:00000 07:072:00000 P - antenna change
+ BRAZ  A    4 P 07:072:00000 12:262:54840 P - antenna change
+ BRAZ  A    5 P 12:262:54840 12:332:59460 P - antenna change
+ BRAZ  A    6 P 12:332:59460 13:115:73920 P - antenna change
+ BRAZ  A    7 P 13:115:73920 14:337:00000 P - unknown
+ BRAZ  A    8 P 14:337:00000 15:105:59340 P - antenna change
+ BRAZ  A    9 P 15:105:59340 16:272:48600 P - antenna change
+ BRAZ  A   10 P 16:272:48600 00:000:00000 P - 
+ BRAZ  A    1 P 00:000:00000 00:000:00000 V - 
+ BREW  A    1 P 00:000:00000 00:000:00000 P - 
+ BREW  A    1 P 00:000:00000 00:000:00000 V - 
+ BRFT  A    1 P 00:000:00000 06:129:00000 P - unknown
+ BRFT  A    2 P 06:129:00000 07:177:00000 P - unknown
+ BRFT  A    3 P 07:177:00000 11:005:00000 P - unknown
+ BRFT  A    4 P 11:005:00000 11:105:00000 P - unknown
+ BRFT  A    5 P 11:105:00000 15:004:00000 P - unknown
+ BRFT  A    6 P 15:004:00000 17:357:00000 P - unknown
+ BRFT  A    7 P 17:357:00000 00:000:00000 P - 
+ BRFT  A    1 P 00:000:00000 11:105:00000 V - unknown
+ BRFT  A    2 P 11:105:00000 00:000:00000 V - 
+ BRMU  A    1 P 00:000:00000 03:071:00000 P - antenna change
+ BRMU  A    2 P 03:071:00000 11:271:00000 P - antenna change
+ BRMU  A    3 P 11:271:00000 00:000:00000 P - 
+ BRMU  A    1 P 00:000:00000 00:000:00000 V - 
+ BRST  A    1 P 00:000:00000 06:207:00000 P - antenna change
+ BRST  A    2 P 06:207:00000 07:109:64800 P - antenna change
+ BRST  A    3 P 07:109:64800 08:163:36000 P - antenna change
+ BRST  A    4 P 08:163:36000 11:299:28800 P - antenna change
+ BRST  A    5 P 11:299:28800 00:000:00000 P - 
+ BRST  A    1 P 00:000:00000 00:000:00000 V - 
+ BRUS  A    1 P 00:000:00000 00:118:44100 P - antenna change
+ BRUS  A    2 P 00:118:44100 11:204:00000 P - unknown
+ BRUS  A    3 P 11:204:00000 00:000:00000 P - 
+ BRUS  A    1 P 00:000:00000 00:000:00000 V - 
+ BRUX  A    1 P 00:000:00000 12:088:00000 P - unknown
+ BRUX  A    2 P 12:088:00000 00:000:00000 P - 
+ BRUX  A    1 P 00:000:00000 00:000:00000 V - 
+ BSHM  A    1 P 00:000:00000 00:168:00000 P - unknown
+ BSHM  A    2 P 00:168:00000 02:028:00000 P - unknown
+ BSHM  A    3 P 02:028:00000 09:201:00000 P - antenna change
+ BSHM  A    4 P 09:201:00000 00:000:00000 P - 
+ BSHM  A    1 P 00:000:00000 00:000:00000 V - 
+ BUCU  A    1 P 00:000:00000 99:229:00099 P - EQ M7.6 - western Turkey
+ BUCU  A    2 P 99:229:00099 08:305:36000 P - antenna change
+ BUCU  A    3 P 08:305:36000 00:000:00000 P - 
+ BUCU  A    1 P 00:000:00000 00:000:00000 V - 
+ CAGL  A    1 P 00:000:00000 01:192:00000 P - antenna change
+ CAGL  A    2 P 01:192:00000 00:000:00000 P - 
+ CAGL  A    1 P 00:000:00000 00:000:00000 V - 
+ CAGZ  A    1 P 00:000:00000 00:000:00000 P - 
+ CAGZ  A    1 P 00:000:00000 00:000:00000 V - 
+ CAS1  A    1 P 00:000:00000 98:196:00000 P - unknown
+ CAS1  A    2 P 98:196:00000 99:343:00000 P - receiver change
+ CAS1  A    3 P 99:343:00000 10:032:00000 P - unknown
+ CAS1  A    4 P 10:032:00000 13:345:10800 P - antenna change
+ CAS1  A    5 P 13:345:10800 00:000:00000 P - 
+ CAS1  A    1 P 00:000:00000 13:345:10800 V - antenna change
+ CAS1  A    2 P 13:345:10800 00:000:00000 V - 
+ CEDU  A    1 P 00:000:00000 97:253:00000 P - antenna change
+ CEDU  A    2 P 97:253:00000 16:291:00000 P - antenna change
+ CEDU  A    3 P 16:291:00000 00:000:00000 P - 
+ CEDU  A    1 P 00:000:00000 00:000:00000 V - 
+ CFAG  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ CFAG  A    2 P 10:058:23652 00:000:00000 P - 
+ CFAG  A    1 P 00:000:00000 00:000:00000 V - 
+ CHAN  A    1 P 00:000:00000 07:319:00000 P - antenna change
+ CHAN  A    2 P 07:319:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ CHAN  A    3 P 11:070:20783 00:000:00000 P - 
+ CHAN  A    1 P 00:000:00000 00:000:00000 V - 
+ CHAT  A    1 P 00:000:00000 01:332:10800 P - antenna change
+ CHAT  A    2 P 01:332:10800 00:000:00000 P - 
+ CHAT  A    1 P 00:000:00000 00:000:00000 V - 
+ CHPI  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ CHPI  A    2 P 10:058:23652 13:211:73740 P - antenna change
+ CHPI  A    3 P 13:211:73740 00:000:00000 P - 
+ CHPI  A    1 P 00:000:00000 00:000:00000 V - 
+ CHTI  A    1 P 00:000:00000 16:318:39779 P - EQ M7.8 - 56km NNE of Amberley, New Zealand
+ CHTI  A    2 P 16:318:39779 19:304:02100 P - antenna change
+ CHTI  A    3 P 19:304:02100 00:000:00000 P - 
+ CHTI  A    1 P 00:000:00000 00:000:00000 V - 
+ CHUM  A    1 P 00:000:00000 03:260:00000 P - antenna change
+ CHUM  A    2 P 03:260:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ CHUM  A    3 P 11:070:20783 00:000:00000 P - 
+ CHUM  A    1 P 00:000:00000 00:000:00000 V - 
+ CHUR  A    1 P 00:000:00000 00:201:67080 P - antenna change
+ CHUR  A    2 P 00:201:67080 04:269:73560 P - antenna change
+ CHUR  A    3 P 04:269:73560 05:034:00000 P - antenna change
+ CHUR  A    4 P 05:034:00000 08:088:53220 P - antenna change
+ CHUR  A    5 P 08:088:53220 09:091:00000 P - antenna change
+ CHUR  A    6 P 09:091:00000 10:245:00000 P - antenna change
+ CHUR  A    7 P 10:245:00000 00:000:00000 P - 
+ CHUR  A    1 P 00:000:00000 00:000:00000 V - 
+ CKIS  A    1 P 00:000:00000 11:277:50400 P - antenna change
+ CKIS  A    2 P 11:277:50400 17:339:02700 P - antenna change
+ CKIS  A    3 P 17:339:02700 00:000:00000 P - 
+ CKIS  A    1 P 00:000:00000 00:000:00000 V - 
+ CNMR  A    1 P 00:000:00000 05:193:00000 P - unknown
+ CNMR  A    2 P 05:193:00000 08:036:00000 P - antenna change
+ CNMR  A    3 P 08:036:00000 19:203:54000 P - antenna change
+ CNMR  A    4 P 19:203:54000 00:000:00000 P - 
+ CNMR  A    1 P 00:000:00000 00:000:00000 V - 
+ COCO  A    1 P 00:000:00000 00:170:53053 P - EQ M7.9 - South Indian Ocean
+ COCO  A    2 P 00:170:53053 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ COCO  A    3 P 04:361:03530 05:087:58177 P - EQ M8.6 - northern Sumatra, Indonesia
+ COCO  A    4 P 05:087:58177 07:255:40227 P - EQ M8.5 - southern Sumatra, Indonesia
+ COCO  A    5 P 07:255:40227 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ COCO  A    6 P 12:102:31117 16:062:46188 P - EQ M7.8 - southwest of Sumatra
+ COCO  A    7 P 16:062:46188 00:000:00000 P - 
+ COCO  A    1 P 00:000:00000 00:000:00000 V - 
+ CONZ  A    1 P 00:000:00000 03:099:00000 P - unknown
+ CONZ  A    2 P 03:099:00000 05:137:52200 P - antenna change
+ CONZ  A    3 P 05:137:52200 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ CONZ  A    4 P 10:058:23652 10:064:42427 P - EQ M6.6 - offshore Bio-Bio, Chile
+ CONZ  A    5 P 10:064:42427 11:043:04621 P - EQ M6.1 - Bio-Bio, Chile
+ CONZ  A    6 P 11:043:04621 11:200:73800 P - antenna change
+ CONZ  A    7 P 11:200:73800 00:000:00000 P - 
+ CONZ  A    1 P 00:000:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ CONZ  A    2 P 10:058:23652 00:000:00000 V - 
+ CRAO  A    1 P 00:000:00000 09:063:00000 P - antenna change
+ CRAO  A    2 P 09:063:00000 00:000:00000 P - 
+ CRAO  A    1 P 00:000:00000 00:000:00000 V - 
+ CRO1  A    1 P 00:000:00000 95:286:00000 P - antenna change
+ CRO1  A    2 P 95:286:00000 99:273:61200 P - receiver change
+ CRO1  A    3 P 99:273:61200 00:105:00000 P - receiver change
+ CRO1  A    4 P 00:105:00000 00:319:00000 P - receiver change
+ CRO1  A    5 P 00:319:00000 01:145:00000 P - receiver change
+ CRO1  A    6 P 01:145:00000 05:216:00000 P - antenna change
+ CRO1  A    7 P 05:216:00000 06:055:00000 P - receiver change
+ CRO1  A    8 P 06:055:00000 10:189:00000 P - receiver change
+ CRO1  A    9 P 10:189:00000 15:267:61200 P - antenna change
+ CRO1  A   10 P 15:267:61200 18:061:00000 P - receiver change
+ CRO1  A   11 P 18:061:00000 00:000:00000 P - 
+ CRO1  A    1 P 00:000:00000 00:000:00000 V - 
+ CUSV  A    1 P 00:000:00000 11:062:00000 P - non linearity
+ CUSV  A    2 P 11:062:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ CUSV  A    3 P 12:102:31117 15:166:00000 P - antenna change
+ CUSV  A    4 P 15:166:00000 00:000:00000 P - 
+ CUSV  A    1 P 00:000:00000 11:062:00000 V - non linearity
+ CUSV  A    2 P 11:062:00000 12:102:31117 V - EQ M8.6 - off the west coast of northern Sumatra
+ CUSV  A    3 P 12:102:31117 00:000:00000 V - 
+ DAEJ  A    1 P 00:000:00000 10:258:00000 P - antenna change
+ DAEJ  A    2 P 10:258:00000 11:012:43200 P - antenna change
+ DAEJ  A    3 P 11:012:43200 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ DAEJ  A    4 P 11:070:20783 15:314:00000 P - non linearity
+ DAEJ  A    5 P 15:314:00000 00:000:00000 P - 
+ DAEJ  A    1 P 00:000:00000 15:314:00000 V - non linearity
+ DAEJ  A    2 P 15:314:00000 00:000:00000 V - 
+ DAKR  A    1 P 00:000:00000 14:126:00000 P - unknown
+ DAKR  A    2 P 14:126:00000 15:111:00000 P - unknown
+ DAKR  A    3 P 15:111:00000 00:000:00000 P - 
+ DAKR  A    1 P 00:000:00000 00:000:00000 V - 
+ DARW  A    1 P 00:000:00000 96:183:00000 P - antenna change
+ DARW  A    2 P 96:183:00000 01:292:00000 P - antenna change
+ DARW  A    3 P 01:292:00000 01:348:00000 P - antenna change
+ DARW  A    4 P 01:348:00000 03:094:03600 P - antenna change
+ DARW  A    5 P 03:094:03600 17:185:00000 P - antenna change
+ DARW  A    6 P 17:185:00000 00:000:00000 P - 
+ DARW  A    1 P 00:000:00000 00:000:00000 V - 
+ DAV1  A    1 P 00:000:00000 96:036:00000 P - receiver change
+ DAV1  A    2 P 96:036:00000 99:238:00000 P - receiver change
+ DAV1  A    3 P 99:238:00000 07:213:25200 P - antenna change
+ DAV1  A    4 P 07:213:25200 11:052:00000 P - antenna change
+ DAV1  A    5 P 11:052:00000 00:000:00000 P - 
+ DAV1  A    1 P 00:000:00000 00:000:00000 V - 
+ DGAR  A    1 P 00:000:00000 96:303:00000 P - unknown
+ DGAR  A    2 P 96:303:00000 04:139:00000 P - antenna change
+ DGAR  A    3 P 04:139:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ DGAR  A    4 P 04:361:03530 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ DGAR  A    5 P 12:102:31117 00:000:00000 P - 
+ DGAR  A    1 P 00:000:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ DGAR  A    2 P 04:361:03530 12:102:31117 V - EQ M8.6 - off the west coast of northern Sumatra
+ DGAR  A    3 P 12:102:31117 00:000:00000 V - 
+ DGAV  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ DGAV  A    2 P 12:102:31117 00:000:00000 P - 
+ DGAV  A    1 P 00:000:00000 12:102:31117 V - EQ M8.6 - off the west coast of northern Sumatra
+ DGAV  A    2 P 12:102:31117 00:000:00000 V - 
+ DRAG  A    1 P 00:000:00000 00:000:00000 P - 
+ DRAG  A    1 P 00:000:00000 00:000:00000 V - 
+ DRAO  A    1 P 00:000:00000 94:041:64260 P - antenna change
+ DRAO  A    2 P 94:041:64260 12:297:00000 P - unknown
+ DRAO  A    3 P 12:297:00000 13:070:73080 P - antenna change
+ DRAO  A    4 P 13:070:73080 00:000:00000 P - 
+ DRAO  A    1 P 00:000:00000 00:000:00000 V - 
+ DUBO  A    1 P 00:000:00000 96:312:00000 P - unknown
+ DUBO  A    2 P 96:312:00000 97:008:71400 P - antenna change
+ DUBO  A    3 P 97:008:71400 99:277:78360 P - antenna change
+ DUBO  A    4 P 99:277:78360 09:239:66780 P - antenna change
+ DUBO  A    5 P 09:239:66780 00:000:00000 P - 
+ DUBO  A    1 P 00:000:00000 00:000:00000 V - 
+ DUM1  A    1 P 00:000:00000 96:020:00000 P - unknown
+ DUM1  A    2 P 96:020:00000 97:354:00000 P - antenna change
+ DUM1  A    3 P 97:354:00000 98:084:11545 P - EQ M8.1 - Balleny Islands region
+ DUM1  A    4 P 98:084:11545 00:000:00000 P - 
+ DUM1  A    1 P 00:000:00000 00:000:00000 V - 
+ EBRE  A    1 P 00:000:00000 97:105:36780 P - antenna change
+ EBRE  A    2 P 97:105:36780 13:186:37200 P - antenna change
+ EBRE  A    3 P 13:186:37200 14:343:47640 P - antenna change
+ EBRE  A    4 P 14:343:47640 16:349:40020 P - antenna change
+ EBRE  A    5 P 16:349:40020 00:000:00000 P - 
+ EBRE  A    1 P 00:000:00000 00:000:00000 V - 
+ EISL  A    1 P 00:000:00000 03:038:79200 P - antenna change
+ EISL  A    2 P 03:038:79200 04:045:54000 P - antenna change
+ EISL  A    3 P 04:045:54000 00:000:00000 P - 
+ EISL  A    1 P 00:000:00000 00:000:00000 V - 
+ FAA1  A    1 P 00:000:00000 12:340:00000 P - antenna change
+ FAA1  A    2 P 12:340:00000 00:000:00000 P - 
+ FAA1  A    1 P 00:000:00000 00:000:00000 V - 
+ FAIR  A    1 P 00:000:00000 96:107:00000 P - antenna change
+ FAIR  A    2 P 96:107:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ FAIR  A    3 P 02:307:79961 04:357:76200 P - antenna change
+ FAIR  A    4 P 04:357:76200 00:000:00000 P - 
+ FAIR  A    1 P 00:000:00000 00:000:00000 V - 
+ FALK  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ FALK  A    2 P 10:058:23652 13:321:32696 P - EQ M7.7 - Scotia Sea
+ FALK  A    3 P 13:321:32696 00:000:00000 P - 
+ FALK  A    1 P 00:000:00000 00:000:00000 V - 
+ FLIN  A    1 P 00:000:00000 97:007:72180 P - antenna change
+ FLIN  A    2 P 97:007:72180 99:264:75180 P - antenna change
+ FLIN  A    3 P 99:264:75180 10:355:46800 P - antenna change
+ FLIN  A    4 P 10:355:46800 00:000:00000 P - 
+ FLIN  A    1 P 00:000:00000 00:000:00000 V - 
+ FLRS  A    1 P 00:000:00000 00:000:00000 P - 
+ FLRS  A    1 P 00:000:00000 00:000:00000 V - 
+ FORT  A    1 P 00:000:00000 00:080:50820 P - antenna change
+ FORT  A    2 P 00:080:50820 06:058:53400 P - antenna change
+ FORT  A    3 P 06:058:53400 00:000:00000 P - 
+ FORT  A    1 P 00:000:00000 00:080:50820 V - antenna change
+ FORT  A    2 P 00:080:50820 00:000:00000 V - 
+ FUNC  A    1 P 00:000:00000 08:095:43200 P - antenna change
+ FUNC  A    2 P 08:095:43200 16:356:00000 P - unknown
+ FUNC  A    3 P 16:356:00000 00:000:00000 P - 
+ FUNC  A    1 P 00:000:00000 00:000:00000 V - 
+ GANP  A    1 P 00:000:00000 06:236:58140 P - antenna & receiver change
+ GANP  A    2 P 06:236:58140 15:041:29880 P - firmware change
+ GANP  A    3 P 15:041:29880 17:037:38400 P - antenna change
+ GANP  A    4 P 17:037:38400 00:000:00000 P - 
+ GANP  A    1 P 00:000:00000 00:000:00000 V - 
+ GLPS  A    1 P 00:000:00000 08:282:00000 P - receiver change
+ GLPS  A    2 P 08:282:00000 12:318:84000 P - antenna change
+ GLPS  A    3 P 12:318:84000 12:341:78300 P - antenna change
+ GLPS  A    4 P 12:341:78300 00:000:00000 P - 
+ GLPS  A    1 P 00:000:00000 00:000:00000 V - 
+ GLSV  A    1 P 00:000:00000 07:317:00000 P - antenna change
+ GLSV  A    2 P 07:317:00000 09:295:00000 P - non linearity
+ GLSV  A    3 P 09:295:00000 19:175:29100 P - antenna change
+ GLSV  A    4 P 19:175:29100 00:000:00000 P - 
+ GLSV  A    1 P 00:000:00000 09:295:00000 V - non linearity
+ GLSV  A    2 P 09:295:00000 00:000:00000 V - 
+ GMAS  A    1 P 00:000:00000 04:044:00000 P - unknown
+ GMAS  A    2 P 04:044:00000 07:342:00000 P - unknown
+ GMAS  A    3 P 07:342:00000 08:043:36000 P - antenna change
+ GMAS  A    4 P 08:043:36000 00:000:00000 P - 
+ GMAS  A    1 P 00:000:00000 00:000:00000 V - 
+ GODE  A    1 P 00:000:00000 12:220:47940 P - antenna change
+ GODE  A    2 P 12:220:47940 12:348:66480 P - antenna change
+ GODE  A    3 P 12:348:66480 13:030:65700 P - antenna change
+ GODE  A    4 P 13:030:65700 00:000:00000 P - 
+ GODE  A    1 P 00:000:00000 00:000:00000 V - 
+ GODZ  A    1 P 00:000:00000 12:220:47940 P - antenna change
+ GODZ  A    2 P 12:220:47940 12:348:66480 P - antenna change
+ GODZ  A    3 P 12:348:66480 13:030:65700 P - antenna change
+ GODZ  A    4 P 13:030:65700 00:000:00000 P - 
+ GODZ  A    1 P 00:000:00000 00:000:00000 V - 
+ GOL2  A    1 P 00:000:00000 95:304:00000 P - antenna change
+ GOL2  A    2 P 95:304:00000 99:289:35204 P - EQ M7.1 - Southern California
+ GOL2  A    3 P 99:289:35204 11:256:00000 P - antenna change
+ GOL2  A    4 P 11:256:00000 13:276:00000 P - non linearity
+ GOL2  A    5 P 13:276:00000 19:187:11940 P - EQ M7.1 - Ridgecrest EQ sequence, california
+ GOL2  A    6 P 19:187:11940 00:000:00000 P - 
+ GOL2  A    1 P 00:000:00000 13:276:00000 V - non linearity
+ GOL2  A    2 P 13:276:00000 00:000:00000 V - 
+ GOLD  A    1 P 00:000:00000 95:304:00000 P - antenna change
+ GOLD  A    2 P 95:304:00000 99:289:35204 P - EQ M7.1 - Southern California
+ GOLD  A    3 P 99:289:35204 13:276:00000 P - non linearity
+ GOLD  A    4 P 13:276:00000 19:187:11940 P - EQ M7.1 - Ridgecrest EQ sequence, california
+ GOLD  A    5 P 19:187:11940 00:000:00000 P - 
+ GOLD  A    1 P 00:000:00000 13:276:00000 V - non linearity
+ GOLD  A    2 P 13:276:00000 00:000:00000 V - 
+ GOUG  A    1 P 00:000:00000 07:205:00000 P - cable repair
+ GOUG  A    2 P 07:205:00000 13:258:00000 P - antenna change
+ GOUG  A    3 P 13:258:00000 00:000:00000 P - 
+ GOUG  A    1 P 00:000:00000 00:000:00000 V - 
+ GRAS  A    1 P 00:000:00000 96:277:00000 P - antenna change
+ GRAS  A    2 P 96:277:00000 03:113:00000 P - antenna change
+ GRAS  A    3 P 03:113:00000 04:295:32400 P - antenna change
+ GRAS  A    4 P 04:295:32400 00:000:00000 P - 
+ GRAS  A    1 P 00:000:00000 00:000:00000 V - 
+ GRAZ  A    1 P 00:000:00000 96:177:50400 P - antenna change
+ GRAZ  A    2 P 96:177:50400 01:127:28800 P - antenna change
+ GRAZ  A    3 P 01:127:28800 01:152:00000 P - receiver change
+ GRAZ  A    4 P 01:152:00000 05:081:39000 P - antenna change
+ GRAZ  A    5 P 05:081:39000 05:306:43740 P - antenna change
+ GRAZ  A    6 P 05:306:43740 10:138:32400 P - antenna change
+ GRAZ  A    7 P 10:138:32400 16:294:39060 P - antenna change
+ GRAZ  A    8 P 16:294:39060 00:000:00000 P - 
+ GRAZ  A    1 P 00:000:00000 00:000:00000 V - 
+ GUAM  A    1 P 00:000:00000 02:116:57967 P - EQ M7.1 - Guam region
+ GUAM  A    2 P 02:116:57967 06:142:00000 P - antenna change
+ GUAM  A    3 P 06:142:00000 19:066:03480 P - antenna change
+ GUAM  A    4 P 19:066:03480 00:000:00000 P - 
+ GUAM  A    1 P 00:000:00000 02:116:57967 V - EQ M7.1 - Guam region
+ GUAM  A    2 P 02:116:57967 00:000:00000 V - 
+ GUAO  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ GUAO  A    2 P 11:070:20783 11:189:00000 P - receiver change
+ GUAO  A    3 P 11:189:00000 00:000:00000 P - 
+ GUAO  A    1 P 00:000:00000 00:000:00000 V - 
+ GUAT  A    1 P 00:000:00000 07:164:70180 P - EQ M6.7 - offshore Guatemala
+ GUAT  A    2 P 07:164:70180 11:332:00000 P - antenna change
+ GUAT  A    3 P 11:332:00000 12:179:00000 P - unknown
+ GUAT  A    4 P 12:179:00000 12:312:59747 P - EQ M7.4 - offshore Guatemala
+ GUAT  A    5 P 12:312:59747 00:000:00000 P - 
+ GUAT  A    1 P 00:000:00000 12:312:59747 V - EQ M7.4 - offshore Guatemala
+ GUAT  A    2 P 12:312:59747 00:000:00000 V - 
+ GUUG  A    1 P 00:000:00000 08:038:00000 P - antenna change
+ GUUG  A    2 P 08:038:00000 11:177:00000 P - antenna change
+ GUUG  A    3 P 11:177:00000 14:260:22485 P - EQ M6.7 - 43km NW of Piti Village, Guam
+ GUUG  A    4 P 14:260:22485 19:161:04020 P - antenna change
+ GUUG  A    5 P 19:161:04020 00:000:00000 P - 
+ GUUG  A    1 P 00:000:00000 08:038:00000 V - antenna change
+ GUUG  A    2 P 08:038:00000 00:000:00000 V - 
+ HARB  A    1 P 00:000:00000 11:334:00000 P - antenna change
+ HARB  A    2 P 11:334:00000 16:054:32400 P - antenna change
+ HARB  A    3 P 16:054:32400 00:000:00000 P - 
+ HARB  A    1 P 00:000:00000 00:000:00000 V - 
+ HERS  A    1 P 00:000:00000 98:049:00000 P - antenna change
+ HERS  A    2 P 98:049:00000 99:080:00000 P - start of antenna problems
+ HERS  A    3 P 99:080:00000 01:220:54000 P - antenna change
+ HERS  A    4 P 01:220:54000 10:231:43200 P - antenna change
+ HERS  A    5 P 10:231:43200 00:000:00000 P - 
+ HERS  A    1 P 00:000:00000 00:000:00000 V - 
+ HERT  A    1 P 00:000:00000 07:338:45000 P - antenna change
+ HERT  A    2 P 07:338:45000 15:062:43200 P - antenna change
+ HERT  A    3 P 15:062:43200 00:000:00000 P - 
+ HERT  A    1 P 00:000:00000 00:000:00000 V - 
+ HLFX  A    1 P 00:000:00000 13:221:73380 P - antenna change
+ HLFX  A    2 P 13:221:73380 00:000:00000 P - 
+ HLFX  A    1 P 00:000:00000 00:000:00000 V - 
+ HNLC  A    1 P 00:000:00000 00:000:00000 P - 
+ HNLC  A    1 P 00:000:00000 00:000:00000 V - 
+ HOB2  A    1 P 00:000:00000 97:142:00000 P - receiver change
+ HOB2  A    2 P 97:142:00000 99:228:00000 P - receiver change
+ HOB2  A    3 P 99:228:00000 99:334:00000 P - receiver change
+ HOB2  A    4 P 99:334:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ HOB2  A    5 P 04:358:53944 00:000:00000 P - 
+ HOB2  A    1 P 00:000:00000 00:000:00000 V - 
+ HOFN  A    1 P 00:000:00000 01:264:64800 P - antenna change
+ HOFN  A    2 P 01:264:64800 04:237:00000 P - non linearity
+ HOFN  A    3 P 04:237:00000 07:266:61200 P - antenna change
+ HOFN  A    4 P 07:266:61200 13:125:43200 P - antenna change
+ HOFN  A    5 P 13:125:43200 14:237:00000 P - unknown
+ HOFN  A    6 P 14:237:00000 00:000:00000 P - 
+ HOFN  A    1 P 00:000:00000 04:237:00000 V - non linearity
+ HOFN  A    2 P 04:237:00000 14:237:00000 V - unknown
+ HOFN  A    3 P 14:237:00000 00:000:00000 V - 
+ HOLB  A    1 P 00:000:00000 94:123:73080 P - antenna change
+ HOLB  A    2 P 94:123:73080 96:089:06000 P - antenna change
+ HOLB  A    3 P 96:089:06000 02:023:08160 P - antenna change
+ HOLB  A    4 P 02:023:08160 07:011:72000 P - antenna change
+ HOLB  A    5 P 07:011:72000 08:214:82800 P - antenna change
+ HOLB  A    6 P 08:214:82800 12:123:00000 P - antenna change
+ HOLB  A    7 P 12:123:00000 12:302:11049 P - EQ M7.8 - Haida Gwaii, Canada
+ HOLB  A    8 P 12:302:11049 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ HOLB  A    9 P 13:005:32299 14:239:75600 P - antenna change
+ HOLB  A   10 P 14:239:75600 16:167:00000 P - antenna change
+ HOLB  A   11 P 16:167:00000 17:299:00000 P - antenna & receiver change
+ HOLB  A   12 P 17:299:00000 00:000:00000 P - 
+ HOLB  A    1 P 00:000:00000 00:000:00000 V - 
+ HOLM  A    1 P 00:000:00000 02:221:00000 P - antenna change
+ HOLM  A    2 P 02:221:00000 00:000:00000 P - 
+ HOLM  A    1 P 00:000:00000 00:000:00000 V - 
+ HRAO  A    1 P 00:000:00000 98:014:00000 P - antenna change
+ HRAO  A    2 P 98:014:00000 04:324:37800 P - antenna change
+ HRAO  A    3 P 04:324:37800 06:054:00000 P - antenna change
+ HRAO  A    4 P 06:054:00000 07:116:00000 P - antenna change
+ HRAO  A    5 P 07:116:00000 08:045:32400 P - antenna change
+ HRAO  A    6 P 08:045:32400 09:015:00000 P - receiver change
+ HRAO  A    7 P 09:015:00000 13:052:36000 P - antenna change
+ HRAO  A    8 P 13:052:36000 00:000:00000 P - 
+ HRAO  A    1 P 00:000:00000 00:000:00000 V - 
+ HYDE  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ HYDE  A    2 P 04:361:03530 07:330:00000 P - antenna change
+ HYDE  A    3 P 07:330:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ HYDE  A    4 P 12:102:31117 15:233:00000 P - unknown
+ HYDE  A    5 P 15:233:00000 00:000:00000 P - 
+ HYDE  A    1 P 00:000:00000 00:000:00000 V - 
+ IISC  B    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ IISC  B    2 P 04:361:03530 08:192:00000 P - antenna change
+ IISC  B    3 P 08:192:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ IISC  B    4 P 12:102:31117 00:000:00000 P - 
+ IISC  B    1 P 00:000:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ IISC  B    2 P 04:361:03530 00:000:00000 V - 
+ INVK  A    1 P 00:000:00000 03:233:55800 P - antenna change
+ INVK  A    2 P 03:233:55800 00:000:00000 P - 
+ INVK  A    1 P 00:000:00000 00:000:00000 V - 
+ IQAL  A    1 P 00:000:00000 00:000:00000 P - 
+ IQAL  A    1 P 00:000:00000 00:000:00000 V - 
+ IRKM  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ IRKM  A    2 P 11:070:20783 00:000:00000 P - 
+ IRKM  A    1 P 00:000:00000 00:000:00000 V - 
+ IRKT  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ IRKT  A    2 P 11:070:20783 00:000:00000 P - 
+ IRKT  A    1 P 00:000:00000 00:000:00000 V - 
+ ISBA  A    1 P 00:000:00000 11:203:00000 P - unknown
+ ISBA  A    2 P 11:203:00000 11:278:00000 P - antenna change
+ ISBA  A    3 P 11:278:00000 00:000:00000 P - 
+ ISBA  A    1 P 00:000:00000 00:000:00000 V - 
+ ISPA  A    1 P 00:000:00000 12:279:00000 P - antenna change
+ ISPA  A    2 P 12:279:00000 00:000:00000 P - 
+ ISPA  A    1 P 00:000:00000 00:000:00000 V - 
+ JOZE  A    1 P 00:000:00000 04:340:00000 P - unknown
+ JOZE  A    2 P 04:340:00000 18:298:60540 P - antenna change
+ JOZE  A    3 P 18:298:60540 00:000:00000 P - 
+ JOZE  A    1 P 00:000:00000 00:000:00000 V - 
+ KARR  A    1 P 00:000:00000 10:139:00000 P - antenna change
+ KARR  A    2 P 10:139:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ KARR  A    3 P 12:102:31117 13:254:00000 P - antenna change
+ KARR  A    4 P 13:254:00000 00:000:00000 P - 
+ KARR  A    1 P 00:000:00000 00:000:00000 V - 
+ KAT1  A    1 P 00:000:00000 00:000:00000 P - 
+ KAT1  A    1 P 00:000:00000 00:000:00000 V - 
+ KELY  B    1 P 00:000:00000 96:096:21480 P - antenna change
+ KELY  B    2 P 96:096:21480 01:257:62280 P - antenna change
+ KELY  B    3 P 01:257:62280 02:278:00000 P - non linearity
+ KELY  B    4 P 02:278:00000 10:295:00000 P - non linearity
+ KELY  B    5 P 10:295:00000 00:000:00000 P - 
+ KELY  B    1 P 00:000:00000 02:278:00000 V - non linearity
+ KELY  B    2 P 02:278:00000 10:295:00000 V - non linearity
+ KELY  B    3 P 10:295:00000 00:000:00000 V - 
+ KERG  A    1 P 00:000:00000 99:091:00000 P - antenna change
+ KERG  A    2 P 99:091:00000 08:210:49200 P - antenna change
+ KERG  A    3 P 08:210:49200 08:249:42000 P - antenna change
+ KERG  A    4 P 08:249:42000 11:046:09000 P - receiver change
+ KERG  A    5 P 11:046:09000 00:000:00000 P - 
+ KERG  A    1 P 00:000:00000 00:000:00000 V - 
+ KIRI  A    1 P 00:000:00000 11:324:03600 P - antenna change
+ KIRI  A    2 P 11:324:03600 14:322:00000 P - antenna change
+ KIRI  A    3 P 14:322:00000 15:118:00000 P - antenna change
+ KIRI  A    4 P 15:118:00000 00:000:00000 P - 
+ KIRI  A    1 P 00:000:00000 00:000:00000 V - 
+ KIRU  A    1 P 00:000:00000 95:143:00000 P - antenna change
+ KIRU  A    2 P 95:143:00000 00:273:63480 P - antenna change
+ KIRU  A    3 P 00:273:63480 03:071:43200 P - antenna change
+ KIRU  A    4 P 03:071:43200 13:050:46800 P - antenna change
+ KIRU  A    5 P 13:050:46800 19:316:41400 P - antenna change
+ KIRU  A    6 P 19:316:41400 00:000:00000 P - 
+ KIRU  A    1 P 00:000:00000 00:000:00000 V - 
+ KIT3  A    1 P 00:000:00000 12:291:00000 P - antenna change
+ KIT3  A    2 P 12:291:00000 00:000:00000 P - 
+ KIT3  A    1 P 00:000:00000 00:000:00000 V - 
+ KOKB  A    1 P 00:000:00000 96:010:79200 P - antenna change
+ KOKB  A    2 P 96:010:79200 02:267:83880 P - antenna change
+ KOKB  A    3 P 02:267:83880 04:139:77400 P - antenna change
+ KOKB  A    4 P 04:139:77400 00:000:00000 P - 
+ KOKB  A    1 P 00:000:00000 00:000:00000 V - 
+ KOKV  A    1 P 00:000:00000 00:000:00000 P - 
+ KOKV  A    1 P 00:000:00000 00:000:00000 V - 
+ KOSG  A    1 P 00:000:00000 03:076:00000 P - unknown
+ KOSG  A    2 P 03:076:00000 11:256:00000 P - antenna change
+ KOSG  A    3 P 11:256:00000 00:000:00000 P - 
+ KOSG  A    1 P 00:000:00000 00:000:00000 V - 
+ KOUG  A    1 P 00:000:00000 13:084:52620 P - antenna change
+ KOUG  A    2 P 13:084:52620 00:000:00000 P - 
+ KOUG  A    1 P 00:000:00000 00:000:00000 V - 
+ KOUR  A    1 P 00:000:00000 97:279:00000 P - antenna change
+ KOUR  A    2 P 97:279:00000 00:067:00000 P - receiver change
+ KOUR  A    3 P 00:067:00000 02:030:00000 P - antenna change
+ KOUR  A    4 P 02:030:00000 06:183:00000 P - unknown
+ KOUR  A    5 P 06:183:00000 07:171:45000 P - antenna change
+ KOUR  A    6 P 07:171:45000 08:015:50400 P - antenna change
+ KOUR  A    7 P 08:015:50400 12:325:46800 P - antenna change
+ KOUR  A    8 P 12:325:46800 19:282:72000 P - antenna change
+ KOUR  A    9 P 19:282:72000 00:000:00000 P - 
+ KOUR  A    1 P 00:000:00000 00:000:00000 V - 
+ KRGG  A    1 P 00:000:00000 00:000:00000 P - 
+ KRGG  A    1 P 00:000:00000 00:000:00000 V - 
+ KWJ1  A    1 P 00:000:00000 00:000:00000 P - 
+ KWJ1  A    1 P 00:000:00000 00:000:00000 V - 
+ LAUT  A    1 P 00:000:00000 06:123:55600 P - EQ M8.0 - Tonga
+ LAUT  A    2 P 06:123:55600 12:116:06120 P - antenna change
+ LAUT  A    3 P 12:116:06120 17:076:00000 P - antenna change
+ LAUT  A    4 P 17:076:00000 18:231:01180 P - EQ M8.2 - 286km NNE of Ndoi Island Fiji
+ LAUT  A    5 P 18:231:01180 00:000:00000 P - 
+ LAUT  A    1 P 00:000:00000 00:000:00000 V - 
+ LHAS  A    1 P 00:000:00000 97:240:00000 P - antenna change
+ LHAS  A    2 P 97:240:00000 03:183:00000 P - unknown
+ LHAS  A    3 P 03:183:00000 06:209:45000 P - antenna change
+ LHAS  A    4 P 06:209:45000 00:000:00000 P - 
+ LHAS  A    1 P 00:000:00000 00:000:00000 V - 
+ LHAZ  A    1 P 00:000:00000 07:059:32400 P - antenna change
+ LHAZ  A    2 P 07:059:32400 08:280:30646 P - EQ M6.3 - eastern Xizang
+ LHAZ  A    3 P 08:280:30646 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ LHAZ  A    4 P 11:070:20783 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ LHAZ  A    5 P 12:102:31117 13:255:29400 P - antenna change
+ LHAZ  A    6 P 13:255:29400 14:042:28800 P - antenna change
+ LHAZ  A    7 P 14:042:28800 16:076:43200 P - antenna change
+ LHAZ  A    8 P 16:076:43200 00:000:00000 P - 
+ LHAZ  A    1 P 00:000:00000 00:000:00000 V - 
+ LMMF  A    1 P 00:000:00000 09:286:46800 P - antenna change
+ LMMF  A    2 P 09:286:46800 13:175:46800 P - antenna change
+ LMMF  A    3 P 13:175:46800 00:000:00000 P - 
+ LMMF  A    1 P 00:000:00000 00:000:00000 V - 
+ LPAL  A    1 P 00:000:00000 08:191:36000 P - antenna change
+ LPAL  A    2 P 08:191:36000 00:000:00000 P - 
+ LPAL  A    1 P 00:000:00000 00:000:00000 V - 
+ LPGS  A    1 P 00:000:00000 98:055:00000 P - unknown
+ LPGS  A    2 P 98:055:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ LPGS  A    3 P 10:058:23652 12:075:00000 P - antenna change
+ LPGS  A    4 P 12:075:00000 12:278:43200 P - antenna change
+ LPGS  A    5 P 12:278:43200 15:259:82473 P - EQ M8.3 - offshore Illapel, Chile
+ LPGS  A    6 P 15:259:82473 16:343:50400 P - antenna change
+ LPGS  A    7 P 16:343:50400 00:000:00000 P - 
+ LPGS  A    1 P 00:000:00000 00:000:00000 V - 
+ LROC  A    1 P 00:000:00000 14:277:00000 P - unknown
+ LROC  A    2 P 14:277:00000 00:000:00000 P - 
+ LROC  A    1 P 00:000:00000 00:000:00000 V - 
+ MAC1  A    1 P 00:000:00000 95:178:00000 P - receiver change
+ MAC1  A    2 P 95:178:00000 98:084:11545 P - EQ M8.1 - Balleny Islands region
+ MAC1  A    3 P 98:084:11545 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ MAC1  A    4 P 04:358:53944 12:174:16277 P - EQ M5.7 - Macquarie Island region
+ MAC1  A    5 P 12:174:16277 16:252:78380 P - EQ M6.1 - Macquarie Island region
+ MAC1  A    6 P 16:252:78380 16:334:14400 P - antenna change
+ MAC1  A    7 P 16:334:14400 00:000:00000 P - 
+ MAC1  A    1 P 00:000:00000 04:358:53944 V - EQ M8.1 - north of Macquarie Island
+ MAC1  A    2 P 04:358:53944 00:000:00000 V - 
+ MAL2  A    1 P 00:000:00000 08:255:31500 P - antenna change
+ MAL2  A    2 P 08:255:31500 13:094:43200 P - antenna change
+ MAL2  A    3 P 13:094:43200 00:000:00000 P - 
+ MAL2  A    1 P 00:000:00000 00:000:00000 V - 
+ MALI  A    1 P 00:000:00000 97:296:49020 P - antenna change
+ MALI  A    2 P 97:296:49020 01:116:00000 P - receiver change
+ MALI  A    3 P 01:116:00000 00:000:00000 P - 
+ MALI  A    1 P 00:000:00000 00:000:00000 V - 
+ MAR6  A    1 P 00:000:00000 00:000:00000 P - 
+ MAR6  A    1 P 00:000:00000 00:000:00000 V - 
+ MAS1  A    1 P 00:000:00000 96:109:00000 P - antenna change
+ MAS1  A    2 P 96:109:00000 99:226:00000 P - receiver change
+ MAS1  A    3 P 99:226:00000 00:355:00000 P - receiver change
+ MAS1  A    4 P 00:355:00000 08:189:50400 P - antenna change
+ MAS1  A    5 P 08:189:50400 12:170:51600 P - antenna change
+ MAS1  A    6 P 12:170:51600 00:000:00000 P - 
+ MAS1  A    1 P 00:000:00000 00:000:00000 V - 
+ MAT1  A    1 P 00:000:00000 09:154:00000 P - antenna change
+ MAT1  A    2 P 09:154:00000 17:186:51300 P - antenna change
+ MAT1  A    3 P 17:186:51300 00:000:00000 P - 
+ MAT1  A    1 P 00:000:00000 00:000:00000 V - 
+ MATE  A    1 P 00:000:00000 96:109:00000 P - unknown
+ MATE  A    2 P 96:109:00000 96:191:00000 P - antenna change
+ MATE  A    3 P 96:191:00000 99:169:00000 P - antenna change
+ MATE  A    4 P 99:169:00000 08:329:00000 P - antenna change
+ MATE  A    5 P 08:329:00000 17:185:34200 P - antenna change
+ MATE  A    6 P 17:185:34200 00:000:00000 P - 
+ MATE  A    1 P 00:000:00000 00:000:00000 V - 
+ MAUI  A    1 P 00:000:00000 00:000:00000 P - 
+ MAUI  A    1 P 00:000:00000 00:000:00000 V - 
+ MAW1  A    1 P 00:000:00000 00:000:00000 P - 
+ MAW1  A    1 P 00:000:00000 00:000:00000 V - 
+ MBAR  A    1 P 00:000:00000 04:136:00000 P - unknown
+ MBAR  A    2 P 04:136:00000 11:095:46800 P - receiver change
+ MBAR  A    3 P 11:095:46800 00:000:00000 P - 
+ MBAR  A    1 P 00:000:00000 00:000:00000 V - 
+ MCIL  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ MCIL  A    2 P 11:070:20783 13:017:00000 P - antenna change
+ MCIL  A    3 P 13:017:00000 15:057:36000 P - antenna change
+ MCIL  A    4 P 15:057:36000 00:000:00000 P - 
+ MCIL  A    1 P 00:000:00000 00:000:00000 V - 
+ MCM4  A    1 P 00:000:00000 99:037:00000 P - unknown
+ MCM4  A    2 P 99:037:00000 99:250:71220 P - receiver change
+ MCM4  A    3 P 99:250:71220 02:003:00000 P - receiver change
+ MCM4  A    4 P 02:003:00000 00:000:00000 P - 
+ MCM4  A    1 P 00:000:00000 00:000:00000 V - 
+ MDO1  A    1 P 00:000:00000 04:342:00000 P - receiver change
+ MDO1  A    2 P 04:342:00000 13:053:79200 P - antenna change
+ MDO1  A    3 P 13:053:79200 13:221:02460 P - antenna change
+ MDO1  A    4 P 13:221:02460 15:028:00000 P - antenna change
+ MDO1  A    5 P 15:028:00000 00:000:00000 P - 
+ MDO1  A    1 P 00:000:00000 00:000:00000 V - 
+ MDVJ  A    1 P 00:000:00000 00:000:00000 P - 
+ MDVJ  A    1 P 00:000:00000 00:000:00000 V - 
+ MDVO  A    1 P 00:000:00000 95:186:00000 P - antenna change
+ MDVO  A    2 P 95:186:00000 96:207:00000 P - unknown
+ MDVO  A    3 P 96:207:00000 02:352:00000 P - unknown
+ MDVO  A    4 P 02:352:00000 00:000:00000 P - 
+ MDVO  A    1 P 00:000:00000 00:000:00000 V - 
+ MEDI  A    1 P 00:000:00000 97:173:00000 P - non linearity
+ MEDI  A    2 P 97:173:00000 01:093:00000 P - antenna change
+ MEDI  A    3 P 01:093:00000 16:245:43200 P - antenna change
+ MEDI  A    4 P 16:245:43200 18:290:41400 P - antenna change
+ MEDI  A    5 P 18:290:41400 00:000:00000 P - 
+ MEDI  A    1 P 00:000:00000 97:173:00000 V - non linearity
+ MEDI  A    2 P 97:173:00000 00:000:00000 V - 
+ METS  A    1 P 00:000:00000 10:231:52260 P - antenna change
+ METS  A    2 P 10:231:52260 11:340:00000 P - unknown
+ METS  A    3 P 11:340:00000 13:179:42900 P - antenna change
+ METS  A    4 P 13:179:42900 00:000:00000 P - 
+ METS  A    1 P 00:000:00000 00:000:00000 V - 
+ MKEA  A    1 P 00:000:00000 06:288:61669 P - EQ M6.7 - Hawaii region, Hawaii
+ MKEA  A    2 P 06:288:61669 15:023:00000 P - antenna change
+ MKEA  A    3 P 15:023:00000 18:124:81174 P - EQ M6.9 - 19km SSW of Leilani Estates, Hawaii
+ MKEA  A    4 P 18:124:81174 19:352:68400 P - antenna change
+ MKEA  A    5 P 19:352:68400 20:015:00000 P - antenna change
+ MKEA  A    6 P 20:015:00000 00:000:00000 P - 
+ MKEA  A    1 P 00:000:00000 00:000:00000 V - 
+ MOBS  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ MOBS  A    2 P 04:358:53944 00:000:00000 P - 
+ MOBS  A    1 P 00:000:00000 00:000:00000 V - 
+ MONP  A    1 P 00:000:00000 95:213:68400 P - antenna change
+ MONP  A    2 P 95:213:68400 99:289:35204 P - EQ M7.1 - Southern California
+ MONP  A    3 P 99:289:35204 00:082:80160 P - antenna change
+ MONP  A    4 P 00:082:80160 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ MONP  A    5 P 10:094:81643 11:188:00000 P - unknown
+ MONP  A    6 P 11:188:00000 12:268:00000 P - unknown
+ MONP  A    7 P 12:268:00000 14:210:00000 P - unknown
+ MONP  A    8 P 14:210:00000 00:000:00000 P - 
+ MONP  A    1 P 00:000:00000 00:000:00000 V - 
+ MQZG  A    1 P 00:000:00000 01:246:00000 P - antenna change
+ MQZG  A    2 P 01:246:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ MQZG  A    3 P 04:358:53944 05:059:14400 P - antenna change
+ MQZG  A    4 P 05:059:14400 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ MQZG  A    5 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ MQZG  A    6 P 10:246:59748 11:052:85903 P - EQ M6.1 - South Island of New Zealand
+ MQZG  A    7 P 11:052:85903 11:164:08449 P - EQ M5.9 - South Island of New Zealand
+ MQZG  A    8 P 11:164:08449 11:357:08282 P - EQ M5.9 - South Island of New Zealand
+ MQZG  A    9 P 11:357:08282 16:045:00824 P - EQ M5.8 - South Island of New Zealand
+ MQZG  A   10 P 16:045:00824 16:318:39779 P - EQ M7.8 - 56km NNE of Amberley, New Zealand
+ MQZG  A   11 P 16:318:39779 20:029:80340 P - antenna change
+ MQZG  A   12 P 20:029:80340 00:000:00000 P - 
+ MQZG  A    1 P 00:000:00000 00:000:00000 V - 
+ NAIN  A    1 P 00:000:00000 00:000:00000 P - 
+ NAIN  A    1 P 00:000:00000 00:000:00000 V - 
+ NAMA  A    1 P 00:000:00000 00:000:00000 P - 
+ NAMA  A    1 P 00:000:00000 00:000:00000 V - 
+ NANO  A    1 P 00:000:00000 96:045:66000 P - receiver change
+ NANO  A    2 P 96:045:66000 03:009:82800 P - antenna change
+ NANO  A    3 P 03:009:82800 09:268:71400 P - antenna change
+ NANO  A    4 P 09:268:71400 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ NANO  A    5 P 13:005:32299 18:045:81480 P - antenna change
+ NANO  A    6 P 18:045:81480 00:000:00000 P - 
+ NANO  A    1 P 00:000:00000 00:000:00000 V - 
+ NAUR  A    1 P 00:000:00000 07:091:74396 P - EQ M8.1 - Solomon Islands
+ NAUR  A    2 P 07:091:74396 10:196:00000 P - antenna change
+ NAUR  A    3 P 10:196:00000 00:000:00000 P - 
+ NAUR  A    1 P 00:000:00000 07:091:74396 V - EQ M8.1 - Solomon Islands
+ NAUR  A    2 P 07:091:74396 00:000:00000 V - 
+ NICO  A    1 P 00:000:00000 99:233:32400 P - antenna change
+ NICO  A    2 P 99:233:32400 08:162:39600 P - antenna change
+ NICO  A    3 P 08:162:39600 13:197:39600 P - antenna change
+ NICO  A    4 P 13:197:39600 00:000:00000 P - 
+ NICO  A    1 P 00:000:00000 00:000:00000 V - 
+ NIST  A    1 P 00:000:00000 13:326:00000 P - unknown
+ NIST  A    2 P 13:326:00000 00:000:00000 P - 
+ NIST  A    1 P 00:000:00000 00:000:00000 V - 
+ NISU  A    1 P 00:000:00000 06:090:00000 P - unknown
+ NISU  A    2 P 06:090:00000 06:110:00000 P - unknown
+ NISU  A    3 P 06:110:00000 06:165:00000 P - unknown
+ NISU  A    4 P 06:165:00000 00:000:00000 P - 
+ NISU  A    1 P 00:000:00000 00:000:00000 V - 
+ NIUM  A    1 P 00:000:00000 06:123:55600 P - EQ M8.0 - Tonga
+ NIUM  A    2 P 06:123:55600 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ NIUM  A    3 P 09:272:64091 14:072:05400 P - antenna change
+ NIUM  A    4 P 14:072:05400 18:231:01180 P - EQ M8.2 - 286km NNE of Ndoi Island, Fiji
+ NIUM  A    5 P 18:231:01180 00:000:00000 P - 
+ NIUM  A    1 P 00:000:00000 00:000:00000 V - 
+ NKLG  A    1 P 00:000:00000 10:125:57600 P - antenna change
+ NKLG  A    2 P 10:125:57600 00:000:00000 P - 
+ NKLG  A    1 P 00:000:00000 00:000:00000 V - 
+ NLIB  A    1 P 00:000:00000 10:349:69300 P - antenna change
+ NLIB  A    2 P 10:349:69300 15:018:00000 P - unknown
+ NLIB  A    3 P 15:018:00000 18:165:54000 P - antenna change
+ NLIB  A    4 P 18:165:54000 00:000:00000 P - 
+ NLIB  A    1 P 00:000:00000 00:000:00000 V - 
+ NNOR  A    1 P 00:000:00000 12:276:18300 P - antenna change
+ NNOR  A    2 P 12:276:18300 19:298:45900 P - antenna change
+ NNOR  A    3 P 19:298:45900 00:000:00000 P - 
+ NNOR  A    1 P 00:000:00000 00:000:00000 V - 
+ NOT1  A    1 P 00:000:00000 15:281:44100 P - cut off change
+ NOT1  A    2 P 15:281:44100 17:284:34200 P - antenna & receiver change
+ NOT1  A    3 P 17:284:34200 00:000:00000 P - 
+ NOT1  A    1 P 00:000:00000 00:000:00000 V - 
+ NOUM  A    1 P 00:000:00000 97:342:00000 P - antenna change
+ NOUM  A    2 P 97:342:00000 01:327:10800 P - antenna change
+ NOUM  A    3 P 01:327:10800 03:361:57660 P - EQ M7.3 - southeast of the Loyalty Islands
+ NOUM  A    4 P 03:361:57660 00:000:00000 P - 
+ NOUM  A    1 P 00:000:00000 00:000:00000 V - 
+ NOVM  A    1 P 00:000:00000 12:104:00000 P - unknown
+ NOVM  A    2 P 12:104:00000 16:092:00000 P - unknown
+ NOVM  A    3 P 16:092:00000 00:000:00000 P - 
+ NOVM  A    1 P 00:000:00000 12:104:00000 V - unknown
+ NOVM  A    2 P 12:104:00000 00:000:00000 V - 
+ NRC1  A    1 P 00:000:00000 96:183:00000 P - antenna change
+ NRC1  A    2 P 96:183:00000 04:196:57600 P - antenna change
+ NRC1  A    3 P 04:196:57600 11:175:51300 P - antenna change
+ NRC1  A    4 P 11:175:51300 00:000:00000 P - 
+ NRC1  A    1 P 00:000:00000 00:000:00000 V - 
+ NRIL  A    1 P 00:000:00000 00:000:00000 P - 
+ NRIL  A    1 P 00:000:00000 00:000:00000 V - 
+ NRMD  A    1 P 00:000:00000 07:084:02402 P - EQ M7.1 - Vanuatu
+ NRMD  A    2 P 07:084:02402 08:100:45973 P - EQ M7.3 - Loyalty Islands, New Caledonia
+ NRMD  A    3 P 08:100:45973 09:275:00000 P - antenna change
+ NRMD  A    4 P 09:275:00000 10:359:47797 P - EQ M7.3 - Vanuatu region
+ NRMD  A    5 P 10:359:47797 00:000:00000 P - 
+ NRMD  A    1 P 00:000:00000 00:000:00000 V - 
+ NURK  A    1 P 00:000:00000 10:229:00000 P - antenna change
+ NURK  A    2 P 10:229:00000 00:000:00000 P - 
+ NURK  A    1 P 00:000:00000 00:000:00000 V - 
+ NYA1  A    1 P 00:000:00000 99:153:02400 P - antenna change
+ NYA1  A    2 P 99:153:02400 00:000:00000 P - 
+ NYA1  A    1 P 00:000:00000 00:000:00000 V - 
+ NYAL  A    1 P 00:000:00000 98:091:00000 P - non linearity
+ NYAL  A    2 P 98:091:00000 99:239:00000 P - receiver change
+ NYAL  A    3 P 99:239:00000 00:340:00000 P - unknown
+ NYAL  A    4 P 00:340:00000 01:249:00000 P - unknown
+ NYAL  A    5 P 01:249:00000 00:000:00000 P - 
+ NYAL  A    1 P 00:000:00000 98:091:00000 V - non linearity
+ NYAL  A    2 P 98:091:00000 00:000:00000 V - 
+ OHI2  A    1 P 00:000:00000 03:054:00000 P - antenna change
+ OHI2  A    2 P 03:054:00000 09:030:63900 P - antenna change
+ OHI2  A    3 P 09:030:63900 13:038:75600 P - antenna change
+ OHI2  A    4 P 13:038:75600 13:321:32696 P - EQ M7.7 - Scotia Sea
+ OHI2  A    5 P 13:321:32696 14:061:57600 P - antenna change
+ OHI2  A    6 P 14:061:57600 17:058:00000 P - Antenna mount change
+ OHI2  A    7 P 17:058:00000 00:000:00000 P - 
+ OHI2  A    1 P 00:000:00000 00:000:00000 V - 
+ OHI3  A    1 P 00:000:00000 10:022:71100 P - antenna change
+ OHI3  A    2 P 10:022:71100 11:034:79200 P - antenna change
+ OHI3  A    3 P 11:034:79200 13:038:75600 P - antenna change
+ OHI3  A    4 P 13:038:75600 13:271:57600 P - antenna change
+ OHI3  A    5 P 13:271:57600 13:321:32696 P - EQ M7.7 - Scotia Sea
+ OHI3  A    6 P 13:321:32696 00:000:00000 P - 
+ OHI3  A    1 P 00:000:00000 00:000:00000 V - 
+ OHIG  A    1 P 00:000:00000 00:000:00000 P - 
+ OHIG  A    1 P 00:000:00000 00:000:00000 V - 
+ ONSA  A    1 P 00:000:00000 99:033:00000 P - antenna change
+ ONSA  A    2 P 99:033:00000 00:000:00000 P - 
+ ONSA  A    1 P 00:000:00000 00:000:00000 V - 
+ OSN1  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ OSN1  A    2 P 04:361:03530 09:203:00000 P - unknown
+ OSN1  A    3 P 09:203:00000 00:000:00000 P - 
+ OSN1  A    1 P 00:000:00000 00:000:00000 V - 
+ OUS2  A    1 P 00:000:00000 01:286:25200 P - antenna change
+ OUS2  A    2 P 01:286:25200 03:233:43970 P - EQ M7.2 - South Island of New Zealand
+ OUS2  A    3 P 03:233:43970 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ OUS2  A    4 P 04:358:53944 06:170:25200 P - antenna change
+ OUS2  A    5 P 06:170:25200 06:239:79200 P - antenna change
+ OUS2  A    6 P 06:239:79200 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ OUS2  A    7 P 09:196:33749 11:174:18000 P - antenna change
+ OUS2  A    8 P 11:174:18000 16:318:39777 P - EQ M7.8 - 54km NNE of Amberley, New Zealand
+ OUS2  A    9 P 16:318:39777 19:268:30600 P - antenna change
+ OUS2  A   10 P 19:268:30600 00:000:00000 P - 
+ OUS2  A    1 P 00:000:00000 00:000:00000 V - 
+ PARC  A    1 P 00:000:00000 01:345:74520 P - antenna change
+ PARC  A    2 P 01:345:74520 09:305:00000 P - antenna change
+ PARC  A    3 P 09:305:00000 11:237:00000 P - unknown
+ PARC  A    4 P 11:237:00000 00:000:00000 P - 
+ PARC  A    1 P 00:000:00000 00:000:00000 V - 
+ PDEL  A    1 P 00:000:00000 06:347:00000 P - unknown
+ PDEL  A    2 P 06:347:00000 08:096:45000 P - antenna change
+ PDEL  A    3 P 08:096:45000 12:291:43200 P - antenna change
+ PDEL  A    4 P 12:291:43200 00:000:00000 P - 
+ PDEL  A    1 P 00:000:00000 00:000:00000 V - 
+ PERT  A    1 P 00:000:00000 94:117:00000 P - antenna change
+ PERT  A    2 P 94:117:00000 01:158:00000 P - antenna change
+ PERT  A    3 P 01:158:00000 03:156:00000 P - antenna change
+ PERT  A    4 P 03:156:00000 08:312:00000 P - unknown
+ PERT  A    5 P 08:312:00000 09:322:00000 P - unknown
+ PERT  A    6 P 09:322:00000 09:349:00000 P - unknown
+ PERT  A    7 P 09:349:00000 12:297:19800 P - antenna change
+ PERT  A    8 P 12:297:19800 00:000:00000 P - 
+ PERT  A    1 P 00:000:00000 00:000:00000 V - 
+ PIE1  A    1 P 00:000:00000 99:152:00000 P - antenna change
+ PIE1  A    2 P 99:152:00000 07:023:64800 P - antenna change
+ PIE1  A    3 P 07:023:64800 00:000:00000 P - 
+ PIE1  A    1 P 00:000:00000 99:152:00000 V - antenna change
+ PIE1  A    2 P 99:152:00000 07:023:64800 V - antenna change
+ PIE1  A    3 P 07:023:64800 00:000:00000 V - 
+ POHN  A    1 P 00:000:00000 11:010:00000 P - unknown
+ POHN  A    2 P 11:010:00000 11:341:00000 P - antenna change
+ POHN  A    3 P 11:341:00000 14:316:14400 P - antenna change
+ POHN  A    4 P 14:316:14400 15:226:00000 P - antenna change
+ POHN  A    5 P 15:226:00000 17:349:10800 P - antenna change
+ POHN  A    6 P 17:349:10800 00:000:00000 P - 
+ POHN  A    1 P 00:000:00000 00:000:00000 V - 
+ POL2  A    1 P 00:000:00000 01:157:00000 P - receiver change
+ POL2  A    2 P 01:157:00000 02:064:00000 P - antenna change
+ POL2  A    3 P 02:064:00000 09:296:00000 P - antenna change
+ POL2  A    4 P 09:296:00000 00:000:00000 P - 
+ POL2  A    1 P 00:000:00000 00:000:00000 V - 
+ POLV  A    1 P 00:000:00000 13:044:39600 P - antenna change
+ POLV  A    2 P 13:044:39600 00:000:00000 P - 
+ POLV  A    1 P 00:000:00000 00:000:00000 V - 
+ POTS  A    1 P 00:000:00000 94:301:00000 P - antenna change
+ POTS  A    2 P 94:301:00000 95:276:28800 P - antenna change
+ POTS  A    3 P 95:276:28800 09:105:47700 P - antenna change
+ POTS  A    4 P 09:105:47700 11:046:61200 P - antenna change
+ POTS  A    5 P 11:046:61200 18:198:36000 P - antenna change
+ POTS  A    6 P 18:198:36000 00:000:00000 P - 
+ POTS  A    1 P 00:000:00000 00:000:00000 V - 
+ PRDS  A    1 P 00:000:00000 02:305:00000 P - antenna change
+ PRDS  A    2 P 02:305:00000 03:141:00000 P - antenna change
+ PRDS  A    3 P 03:141:00000 06:199:66900 P - antenna change
+ PRDS  A    4 P 06:199:66900 12:209:72000 P - antenna change
+ PRDS  A    5 P 12:209:72000 00:000:00000 P - 
+ PRDS  A    1 P 00:000:00000 00:000:00000 V - 
+ PRE1  A    1 P 00:000:00000 06:339:00000 P - unknown
+ PRE1  A    2 P 06:339:00000 07:130:00000 P - unknown
+ PRE1  A    3 P 07:130:00000 00:000:00000 P - 
+ PRE1  A    1 P 00:000:00000 00:000:00000 V - 
+ QAQ1  A    1 P 00:000:00000 03:248:43200 P - antenna change
+ QAQ1  A    2 P 03:248:43200 03:272:40860 P - antenna change
+ QAQ1  A    3 P 03:272:40860 03:364:61740 P - antenna change
+ QAQ1  A    4 P 03:364:61740 09:238:00000 P - non linearity
+ QAQ1  A    5 P 09:238:00000 13:180:00000 P - non linearity
+ QAQ1  A    6 P 13:180:00000 00:000:00000 P - 
+ QAQ1  A    1 P 00:000:00000 09:238:00000 V - non linearity
+ QAQ1  A    2 P 09:238:00000 13:180:00000 V - non linearity
+ QAQ1  A    3 P 13:180:00000 00:000:00000 V - 
+ QIKI  A    1 P 00:000:00000 00:000:00000 P - 
+ QIKI  A    1 P 00:000:00000 00:000:00000 V - 
+ QUIN  A    1 P 00:000:00000 98:091:70200 P - antenna change
+ QUIN  A    2 P 98:091:70200 09:015:00000 P - antenna change
+ QUIN  A    3 P 09:015:00000 10:224:03900 P - antenna change
+ QUIN  A    4 P 10:224:03900 00:000:00000 P - 
+ QUIN  A    1 P 00:000:00000 00:000:00000 V - 
+ RABT  A    1 P 00:000:00000 00:000:00000 P - 
+ RABT  A    1 P 00:000:00000 00:000:00000 V - 
+ RAMO  A    1 P 00:000:00000 00:199:00000 P - antenna change
+ RAMO  A    2 P 00:199:00000 04:078:00000 P - antenna change
+ RAMO  A    3 P 04:078:00000 00:000:00000 P - 
+ RAMO  A    1 P 00:000:00000 00:000:00000 V - 
+ RCMN  A    1 P 00:000:00000 00:000:00000 P - 
+ RCMN  A    1 P 00:000:00000 00:000:00000 V - 
+ RECF  A    1 P 00:000:00000 04:248:00000 P - antenna change
+ RECF  A    2 P 04:248:00000 07:128:00000 P - antenna change
+ RECF  A    3 P 07:128:00000 12:241:62520 P - antenna change
+ RECF  A    4 P 12:241:62520 12:327:57600 P - receiver change
+ RECF  A    5 P 12:327:57600 15:079:53220 P - antenna change
+ RECF  A    6 P 15:079:53220 17:284:59400 P - antenna change
+ RECF  A    7 P 17:284:59400 00:000:00000 P - 
+ RECF  A    1 P 00:000:00000 00:000:00000 V - 
+ RESO  A    1 P 00:000:00000 04:051:00000 P - receiver change
+ RESO  A    2 P 04:051:00000 00:000:00000 P - 
+ RESO  A    1 P 00:000:00000 00:000:00000 V - 
+ REUN  A    1 P 00:000:00000 03:094:36000 P - antenna change
+ REUN  A    2 P 03:094:36000 08:338:43200 P - antenna change
+ REUN  A    3 P 08:338:43200 00:000:00000 P - 
+ REUN  A    1 P 00:000:00000 08:338:43200 V - antenna change
+ REUN  A    2 P 08:338:43200 00:000:00000 V - 
+ RIGA  A    1 P 00:000:00000 05:013:36480 P - antenna change
+ RIGA  A    2 P 05:013:36480 06:142:00000 P - antenna change
+ RIGA  A    3 P 06:142:00000 07:350:43200 P - antenna change
+ RIGA  A    4 P 07:350:43200 13:345:54000 P - antenna change
+ RIGA  A    5 P 13:345:54000 14:354:00000 P - unknown
+ RIGA  A    6 P 14:354:00000 00:000:00000 P - 
+ RIGA  A    1 P 00:000:00000 00:000:00000 V - 
+ RIO2  A    1 P 00:000:00000 12:283:77400 P - antenna change
+ RIO2  A    2 P 12:283:77400 20:051:54000 P - antenna change
+ RIO2  A    3 P 20:051:54000 00:000:00000 P - 
+ RIO2  A    1 P 00:000:00000 00:000:00000 V - 
+ RIOG  A    1 P 00:000:00000 96:317:00000 P - antenna change
+ RIOG  A    2 P 96:317:00000 99:337:47700 P - antenna change
+ RIOG  A    3 P 99:337:47700 07:036:00000 P - unknown
+ RIOG  A    4 P 07:036:00000 00:000:00000 P - 
+ RIOG  A    1 P 00:000:00000 00:000:00000 V - 
+ SALU  A    1 P 00:000:00000 13:162:62700 P - antenna change
+ SALU  A    2 P 13:162:62700 14:311:75300 P - antenna change
+ SALU  A    3 P 14:311:75300 16:160:60300 P - antenna change
+ SALU  A    4 P 16:160:60300 18:099:14400 P - 
+ SALU  A    5 P 18:099:14400 00:000:00000 P - 
+ SALU  A    1 P 00:000:00000 00:000:00000 V - 
+ SANT  A    1 P 00:000:00000 96:199:00000 P - antenna change
+ SANT  A    2 P 96:199:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ SANT  A    3 P 10:058:23652 15:259:82472 P - EQ M8.3 - offshore Illapel, Chile
+ SANT  A    4 P 15:259:82472 17:006:00000 P - Antenna change
+ SANT  A    5 P 17:006:00000 17:114:77910 P - EQ M6.9 - 40km W of Valparaiso, Chile
+ SANT  A    6 P 17:114:77910 18:009:00000 P - Analyse
+ SANT  A    7 P 18:009:00000 18:083:00000 P - Unknown
+ SANT  A    8 P 18:083:00000 00:000:00000 P - 
+ SANT  A    1 P 00:000:00000 15:259:82472 V - EQ M8.3 - offshore Illapel, Chile
+ SANT  A    2 P 15:259:82472 00:000:00000 V - 
+ SAVO  A    1 P 00:000:00000 18:109:57600 P - antenna change
+ SAVO  A    2 P 18:109:57600 00:000:00000 P - 
+ SAVO  A    1 P 00:000:00000 00:000:00000 V - 
+ SCH2  A    1 P 00:000:00000 03:286:00000 P - antenna change
+ SCH2  A    2 P 03:286:00000 08:280:51300 P - antenna change
+ SCH2  A    3 P 08:280:51300 00:000:00000 P - 
+ SCH2  A    1 P 00:000:00000 00:000:00000 V - 
+ SCOR  A    1 P 00:000:00000 00:000:00000 P - 
+ SCOR  A    1 P 00:000:00000 00:000:00000 V - 
+ SCUB  A    1 P 00:000:00000 96:104:00000 P - unknown
+ SCUB  A    2 P 96:104:00000 98:091:00000 P - antenna change
+ SCUB  A    3 P 98:091:00000 00:342:00000 P - antenna change
+ SCUB  A    4 P 00:342:00000 14:352:32400 P - antenna change
+ SCUB  A    5 P 14:352:32400 00:000:00000 P - 
+ SCUB  A    1 P 00:000:00000 00:000:00000 V - 
+ SEYG  A    1 P 00:000:00000 00:000:00000 P - 
+ SEYG  A    1 P 00:000:00000 00:000:00000 V - 
+ SFER  A    1 P 00:000:00000 97:365:00000 P - antenna change
+ SFER  A    2 P 97:365:00000 98:035:00000 P - antenna change
+ SFER  A    3 P 98:035:00000 98:153:00000 P - antenna change
+ SFER  A    4 P 98:153:00000 02:064:00000 P - antenna change
+ SFER  A    5 P 02:064:00000 03:155:00000 P - unknown
+ SFER  A    6 P 03:155:00000 05:199:00000 P - unknown
+ SFER  A    7 P 05:199:00000 14:030:42000 P - antenna change
+ SFER  A    8 P 14:030:42000 19:017:39600 P - antenna change
+ SFER  A    9 P 19:017:39600 00:000:00000 P - 
+ SFER  A    1 P 00:000:00000 00:000:00000 V - 
+ SHAO  A    1 P 00:000:00000 02:183:00000 P - receiver change
+ SHAO  A    2 P 02:183:00000 04:364:07200 P - receiver change
+ SHAO  A    3 P 04:364:07200 07:270:00000 P - receiver change
+ SHAO  A    4 P 07:270:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ SHAO  A    5 P 11:070:20783 00:000:00000 P - 
+ SHAO  A    1 P 00:000:00000 00:000:00000 V - 
+ SOFI  A    1 P 00:000:00000 99:229:00099 P - EQ M7.6 - western Turkey
+ SOFI  A    2 P 99:229:00099 10:119:46800 P - antenna change
+ SOFI  A    3 P 10:119:46800 00:000:00000 P - 
+ SOFI  A    1 P 00:000:00000 00:000:00000 V - 
+ STHL  A    1 P 00:000:00000 00:000:00000 P - 
+ STHL  A    1 P 00:000:00000 00:000:00000 V - 
+ STJO  A    1 P 00:000:00000 94:073:72180 P - antenna change
+ STJO  A    2 P 94:073:72180 95:061:78960 P - antenna change
+ STJO  A    3 P 95:061:78960 95:307:45000 P - antenna change
+ STJO  A    4 P 95:307:45000 96:214:79200 P - antenna change
+ STJO  A    5 P 96:214:79200 00:147:73200 P - antenna change
+ STJO  A    6 P 00:147:73200 13:031:82800 P - antenna change
+ STJO  A    7 P 13:031:82800 00:000:00000 P - 
+ STJO  A    1 P 00:000:00000 00:000:00000 V - 
+ SUTH  A    1 P 00:000:00000 02:058:00000 P - antenna change
+ SUTH  A    2 P 02:058:00000 04:153:00000 P - antenna change
+ SUTH  A    3 P 04:153:00000 00:000:00000 P - 
+ SUTH  A    1 P 00:000:00000 00:000:00000 V - 
+ SUTM  A    1 P 00:000:00000 05:049:00000 P - unknown
+ SUTM  A    2 P 05:049:00000 13:128:00000 P - antenna change
+ SUTM  A    3 P 13:128:00000 19:130:39600 P - antenna change
+ SUTM  A    4 P 19:130:39600 00:000:00000 P - 
+ SUTM  A    1 P 00:000:00000 00:000:00000 V - 
+ SUWN  A    1 P 00:000:00000 00:045:00000 P - antenna change
+ SUWN  A    2 P 00:045:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ SUWN  A    3 P 11:070:20783 13:206:00000 P - antenna change
+ SUWN  A    4 P 13:206:00000 18:036:00000 P - unknown
+ SUWN  A    5 P 18:036:00000 20:012:00000 P - unknown
+ SUWN  A    6 P 20:012:00000 00:000:00000 P - 
+ SUWN  A    1 P 00:000:00000 00:000:00000 V - 
+ SYDN  A    1 P 00:000:00000 00:000:00000 P - 
+ SYDN  A    1 P 00:000:00000 00:000:00000 V - 
+ SYOG  A    1 P 00:000:00000 99:299:00000 P - non linearity
+ SYOG  A    2 P 99:299:00000 07:026:00000 P - receiver change
+ SYOG  A    3 P 07:026:00000 13:357:00000 P - antenna change
+ SYOG  A    4 P 13:357:00000 14:033:32400 P - antenna change
+ SYOG  A    5 P 14:033:32400 20:018:00000 P - antenna change
+ SYOG  A    6 P 20:018:00000 00:000:00000 P - 
+ SYOG  A    1 P 00:000:00000 99:299:00000 V - non linearity
+ SYOG  A    2 P 99:299:00000 00:000:00000 V - 
+ TAEJ  A    1 P 00:000:00000 00:000:00000 P - 
+ TAEJ  A    1 P 00:000:00000 00:000:00000 V - 
+ TAH1  A    1 P 00:000:00000 00:000:00000 P - 
+ TAH1  A    1 P 00:000:00000 00:000:00000 V - 
+ TASH  A    1 P 00:000:00000 03:154:00000 P - antenna change
+ TASH  A    2 P 03:154:00000 09:185:00000 P - non linearity
+ TASH  A    3 P 09:185:00000 10:257:00000 P - antenna change
+ TASH  A    4 P 10:257:00000 15:299:32983 P - EQ M7.5 - 45km E of Farkhar, Afghanistan
+ TASH  A    5 P 15:299:32983 00:000:00000 P - 
+ TASH  A    1 P 00:000:00000 09:185:00000 V - non linearity
+ TASH  A    2 P 09:185:00000 00:000:00000 V - 
+ TCMS  A    1 P 00:000:00000 02:234:03600 P - antenna change
+ TCMS  A    2 P 02:234:03600 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ TCMS  A    3 P 04:361:03530 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ TCMS  A    4 P 11:070:20783 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ TCMS  A    5 P 12:102:31117 18:037:57043 P - EQ M6.4 - 18km NNE of Hualian, Taiwan
+ TCMS  A    6 P 18:037:57043 00:000:00000 P - 
+ TCMS  A    1 P 00:000:00000 00:000:00000 V - 
+ TEHN  A    1 P 00:000:00000 16:145:23400 P - antenna change
+ TEHN  A    2 P 16:145:23400 18:143:00000 P - unknown
+ TEHN  A    3 P 18:143:00000 18:357:00000 P - unknown
+ TEHN  A    4 P 18:357:00000 00:000:00000 P - 
+ TEHN  A    1 P 00:000:00000 00:000:00000 V - 
+ THTI  A    1 P 00:000:00000 98:326:00000 P - antenna change
+ THTI  A    2 P 98:326:00000 04:013:00000 P - antenna change
+ THTI  A    3 P 04:013:00000 00:000:00000 P - 
+ THTI  A    1 P 00:000:00000 00:000:00000 V - 
+ THU2  A    1 P 00:000:00000 04:276:00000 P - non linearity
+ THU2  A    2 P 04:276:00000 11:279:00000 P - non linearity
+ THU2  A    3 P 11:279:00000 00:000:00000 P - 
+ THU2  A    1 P 00:000:00000 04:276:00000 V - non linearity
+ THU2  A    2 P 04:276:00000 11:279:00000 V - non linearity
+ THU2  A    3 P 11:279:00000 00:000:00000 V - 
+ THU3  A    1 P 00:000:00000 04:276:00000 P - non linearity
+ THU3  A    2 P 04:276:00000 11:279:00000 P - non linearity
+ THU3  A    3 P 11:279:00000 00:000:00000 P - 
+ THU3  A    1 P 00:000:00000 04:276:00000 V - non linearity
+ THU3  A    2 P 04:276:00000 11:279:00000 V - non linearity
+ THU3  A    3 P 11:279:00000 00:000:00000 V - 
+ TID1  A    1 P 00:000:00000 00:089:08100 P - receiver change
+ TID1  A    2 P 00:089:08100 04:348:00000 P - antenna change
+ TID1  A    3 P 04:348:00000 16:217:00000 P - antenna change
+ TID1  A    4 P 16:217:00000 00:000:00000 P - 
+ TID1  A    1 P 00:000:00000 00:000:00000 V - 
+ TIDB  A    1 P 00:000:00000 96:178:00000 P - antenna change
+ TIDB  A    2 P 96:178:00000 04:347:00000 P - antenna change
+ TIDB  A    3 P 04:347:00000 16:217:03600 P - antenna change
+ TIDB  A    4 P 16:217:03600 00:000:00000 P - 
+ TIDB  A    1 P 00:000:00000 00:000:00000 V - 
+ TIXI  A    1 P 00:000:00000 02:287:00000 P - antenna change
+ TIXI  A    2 P 02:287:00000 10:293:61200 P - antenna change
+ TIXI  A    3 P 10:293:61200 00:000:00000 P - 
+ TIXI  A    1 P 00:000:00000 00:000:00000 V - 
+ TLSE  A    1 P 00:000:00000 03:335:46800 P - antenna change
+ TLSE  A    2 P 03:335:46800 10:055:51900 P - antenna change
+ TLSE  A    3 P 10:055:51900 12:248:35700 P - antenna change
+ TLSE  A    4 P 12:248:35700 16:071:34200 P - antenna change
+ TLSE  A    5 P 16:071:34200 16:081:39600 P - antenna change
+ TLSE  A    6 P 16:081:39600 00:000:00000 P - 
+ TLSE  A    1 P 00:000:00000 00:000:00000 V - 
+ TNML  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ TNML  A    2 P 04:361:03530 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ TNML  A    3 P 11:070:20783 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ TNML  A    4 P 12:102:31117 18:037:57043 P - EQ M6.4 - 18km NNE of Hualian, Taiwan
+ TNML  A    5 P 18:037:57043 00:000:00000 P - 
+ TNML  A    1 P 00:000:00000 00:000:00000 V - 
+ TOUL  A    1 P 00:000:00000 00:356:00000 P - unknown
+ TOUL  A    2 P 00:356:00000 00:000:00000 P - 
+ TOUL  A    1 P 00:000:00000 00:000:00000 V - 
+ TOW2  A    1 P 00:000:00000 11:266:00000 P - antenna change
+ TOW2  A    2 P 11:266:00000 00:000:00000 P - 
+ TOW2  A    1 P 00:000:00000 00:000:00000 V - 
+ TRAB  A    1 P 00:000:00000 00:000:00000 P - 
+ TRAB  A    1 P 00:000:00000 00:000:00000 V - 
+ TRO1  A    1 P 00:000:00000 98:356:48000 P - antenna change
+ TRO1  A    2 P 98:356:48000 00:144:00000 P - unknown
+ TRO1  A    3 P 00:144:00000 04:195:28800 P - antenna change
+ TRO1  A    4 P 04:195:28800 07:235:51420 P - antenna change
+ TRO1  A    5 P 07:235:51420 10:207:60720 P - antenna change
+ TRO1  A    6 P 10:207:60720 00:000:00000 P - 
+ TRO1  A    1 P 00:000:00000 00:000:00000 V - 
+ TROM  A    1 P 00:000:00000 00:000:00000 P - 
+ TROM  A    1 P 00:000:00000 00:000:00000 V - 
+ TUVA  A    1 P 00:000:00000 04:045:00000 P - receiver change
+ TUVA  A    2 P 04:045:00000 09:280:80331 P - EQ M7.8 - Santa Cruz Islands
+ TUVA  A    3 P 09:280:80331 12:031:00000 P - antenna change
+ TUVA  A    4 P 12:031:00000 17:313:00000 P - antenna change
+ TUVA  A    5 P 17:313:00000 18:231:01180 P - EQ M8.2 - 286km NNE of Ndoi Island Fiji
+ TUVA  A    6 P 18:231:01180 00:000:00000 P - 
+ TUVA  A    1 P 00:000:00000 00:000:00000 V - 
+ UFPR  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ UFPR  A    2 P 10:058:23652 18:094:55800 P - antenna change
+ UFPR  A    3 P 18:094:55800 00:000:00000 P - 
+ UFPR  A    1 P 00:000:00000 00:000:00000 V - 
+ UNBJ  A    1 P 00:000:00000 12:153:52200 P - antenna change
+ UNBJ  A    2 P 12:153:52200 00:000:00000 P - 
+ UNBJ  A    1 P 00:000:00000 00:000:00000 V - 
+ UNSA  A    1 P 00:000:00000 95:211:18684 P - EQ M8.0 - Antofagasta, Chile
+ UNSA  A    2 P 95:211:18684 98:337:00000 P - antenna change
+ UNSA  A    3 P 98:337:00000 01:192:00000 P - antenna change
+ UNSA  A    4 P 01:192:00000 08:206:00000 P - antenna change
+ UNSA  A    5 P 08:206:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ UNSA  A    6 P 10:058:23652 15:120:43200 P - antenna change
+ UNSA  A    7 P 15:120:43200 15:259:82473 P - EQ M8.3 - offshore Illapel, Chile
+ UNSA  A    8 P 15:259:82473 20:048:54000 P - antenna change
+ UNSA  A    9 P 20:048:54000 00:000:00000 P - 
+ UNSA  A    1 P 00:000:00000 08:206:00000 V - antenna change
+ UNSA  A    2 P 08:206:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ UNSA  A    3 P 10:058:23652 15:259:82473 V - EQ M8.3 - offshore Illapel, Chile
+ UNSA  A    4 P 15:259:82473 00:000:00000 V - 
+ USN3  A    1 P 00:000:00000 00:000:00000 P - 
+ USN3  A    1 P 00:000:00000 00:000:00000 V - 
+ USNO  A    1 P 00:000:00000 00:000:00000 P - 
+ USNO  A    1 P 00:000:00000 00:000:00000 V - 
+ UZHL  A    1 P 00:000:00000 10:354:42000 P - antenna change
+ UZHL  A    2 P 10:354:42000 12:312:33600 P - antenna change
+ UZHL  A    3 P 12:312:33600 13:316:28080 P - antenna change
+ UZHL  A    4 P 13:316:28080 00:000:00000 P - 
+ UZHL  A    1 P 00:000:00000 00:000:00000 V - 
+ VACS  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ VACS  A    2 P 12:102:31117 18:172:00000 P - antenna change
+ VACS  A    3 P 18:172:00000 00:000:00000 P - 
+ VACS  A    1 P 00:000:00000 00:000:00000 V - 
+ VESL  A    1 P 00:000:00000 03:006:00000 P - non linearity
+ VESL  A    2 P 03:006:00000 06:023:00000 P - non linearity
+ VESL  A    3 P 06:023:00000 00:000:00000 P - 
+ VESL  A    1 P 00:000:00000 03:006:00000 V - non linearity
+ VESL  A    2 P 03:006:00000 06:023:00000 V - non linearity
+ VESL  A    3 P 06:023:00000 00:000:00000 V - 
+ VNDP  A    1 P 00:000:00000 94:134:00000 P - antenna change
+ VNDP  A    2 P 94:134:00000 95:215:00000 P - antenna change
+ VNDP  A    3 P 95:215:00000 95:313:00000 P - antenna change
+ VNDP  A    4 P 95:313:00000 03:356:69356 P - EQ M6.6 - Central California
+ VNDP  A    5 P 03:356:69356 12:033:00000 P - antenna change
+ VNDP  A    6 P 12:033:00000 15:208:79200 P - antenna change
+ VNDP  A    7 P 15:208:79200 00:000:00000 P - 
+ VNDP  A    1 P 00:000:00000 15:208:79200 V - antenna change
+ VNDP  A    2 P 15:208:79200 00:000:00000 V - 
+ WES2  A    1 P 00:000:00000 94:189:00000 P - antenna change
+ WES2  A    2 P 94:189:00000 94:215:00000 P - antenna change
+ WES2  A    3 P 94:215:00000 95:249:00000 P - antenna change
+ WES2  A    4 P 95:249:00000 95:321:00000 P - receiver change
+ WES2  A    5 P 95:321:00000 96:116:00000 P - unknown
+ WES2  A    6 P 96:116:00000 96:163:00000 P - antenna change
+ WES2  A    7 P 96:163:00000 97:142:00000 P - antenna change
+ WES2  A    8 P 97:142:00000 97:181:79560 P - antenna change
+ WES2  A    9 P 97:181:79560 98:152:54180 P - antenna change
+ WES2  A   10 P 98:152:54180 00:235:63960 P - antenna change
+ WES2  A   11 P 00:235:63960 01:208:00000 P - antenna change
+ WES2  A   12 P 01:208:00000 14:175:50400 P - antenna change
+ WES2  A   13 P 14:175:50400 18:225:50400 P - antenna change
+ WES2  A   14 P 18:225:50400 18:330:56700 P - antenna change
+ WES2  A   15 P 18:330:56700 19:136:54900 P - antenna change
+ WES2  A   16 P 19:136:54900 20:031:55200 P - antenna change
+ WES2  A   17 P 20:031:55200 00:000:00000 P - 
+ WES2  A    1 P 00:000:00000 00:000:00000 V - 
+ WHIT  A    1 P 00:000:00000 95:194:70200 P - antenna change
+ WHIT  A    2 P 95:194:70200 96:159:00000 P - antenna change
+ WHIT  A    3 P 96:159:00000 97:175:60900 P - antenna change
+ WHIT  A    4 P 97:175:60900 02:307:79961 P - EQ M7.9 - Central Alaska
+ WHIT  A    5 P 02:307:79961 09:037:00000 P - antenna change
+ WHIT  A    6 P 09:037:00000 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ WHIT  A    7 P 13:005:32299 00:000:00000 P - 
+ WHIT  A    1 P 00:000:00000 00:000:00000 V - 
+ WILL  A    1 P 00:000:00000 94:172:69420 P - antenna change
+ WILL  A    2 P 94:172:69420 95:188:73620 P - antenna change
+ WILL  A    3 P 95:188:73620 13:295:82800 P - antenna change
+ WILL  A    4 P 13:295:82800 00:000:00000 P - 
+ WILL  A    1 P 00:000:00000 00:000:00000 V - 
+ WIND  A    1 P 00:000:00000 11:059:64800 P - antenna change
+ WIND  A    2 P 11:059:64800 19:134:00000 P - antenna change
+ WIND  A    3 P 19:134:00000 00:000:00000 P - 
+ WIND  A    1 P 00:000:00000 00:000:00000 V - 
+ WSRT  A    1 P 00:000:00000 98:076:54540 P - antenna change
+ WSRT  A    2 P 98:076:54540 17:029:00000 P - switch to igs14.atx
+ WSRT  A    3 P 17:029:00000 00:000:00000 P - 
+ WSRT  A    1 P 00:000:00000 00:000:00000 V - 
+ WTZR  A    1 P 00:000:00000 09:019:35280 P - antenna change
+ WTZR  A    2 P 09:019:35280 10:181:28800 P - antenna change
+ WTZR  A    3 P 10:181:28800 00:000:00000 P - 
+ WTZR  A    1 P 00:000:00000 00:000:00000 V - 
+ WUHN  A    1 P 00:000:00000 99:194:00000 P - unknown
+ WUHN  A    2 P 99:194:00000 00:092:00000 P - unknown
+ WUHN  A    3 P 00:092:00000 00:160:00000 P - antenna change
+ WUHN  A    4 P 00:160:00000 02:026:00000 P - antenna change
+ WUHN  A    5 P 02:026:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ WUHN  A    6 P 04:361:03530 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ WUHN  A    7 P 11:070:20783 11:082:31200 P - antenna change
+ WUHN  A    8 P 11:082:31200 13:322:33000 P - antenna change
+ WUHN  A    9 P 13:322:33000 16:266:00000 P - unknown
+ WUHN  A   10 P 16:266:00000 00:000:00000 P - 
+ WUHN  A    1 P 00:000:00000 00:000:00000 V - 
+ XMIS  A    1 P 00:000:00000 06:198:29969 P - EQ M7.7 - south of Java, Indonesia
+ XMIS  A    2 P 06:198:29969 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ XMIS  A    3 P 12:102:31117 14:177:00000 P - antenna change
+ XMIS  A    4 P 14:177:00000 17:100:00000 P - antenna change
+ XMIS  A    5 P 17:100:00000 00:000:00000 P - 
+ XMIS  A    1 P 00:000:00000 00:000:00000 V - 
+ YAKT  A    1 P 00:000:00000 00:115:00000 P - antenna change
+ YAKT  A    2 P 00:115:00000 00:000:00000 P - 
+ YAKT  A    1 P 00:000:00000 00:000:00000 V - 
+ YAR1  A    1 P 00:000:00000 97:232:00000 P - antenna change
+ YAR1  A    2 P 97:232:00000 00:000:00000 P - 
+ YAR1  A    1 P 00:000:00000 00:000:00000 V - 
+ YAR2  A    1 P 00:000:00000 97:232:00000 P - antenna change
+ YAR2  A    2 P 97:232:00000 02:136:57600 P - antenna change
+ YAR2  A    3 P 02:136:57600 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ YAR2  A    4 P 12:102:31117 13:171:00000 P - antenna change
+ YAR2  A    5 P 13:171:00000 00:000:00000 P - 
+ YAR2  A    1 P 00:000:00000 00:000:00000 V - 
+ YEBE  A    1 P 00:000:00000 00:000:00000 P - 
+ YEBE  A    1 P 00:000:00000 00:000:00000 V - 
+ YELL  A    1 P 00:000:00000 94:075:72000 P - antenna change
+ YELL  A    2 P 94:075:72000 96:235:00000 P - antenna change
+ YELL  A    3 P 96:235:00000 13:198:72000 P - antenna change
+ YELL  A    4 P 13:198:72000 00:000:00000 P - 
+ YELL  A    1 P 00:000:00000 00:000:00000 V - 
+ YIBL  A    1 P 00:000:00000 07:099:00000 P - non linearity
+ YIBL  A    2 P 07:099:00000 14:019:44400 P - receiver change
+ YIBL  A    3 P 14:019:44400 00:000:00000 P - 
+ YIBL  A    1 P 00:000:00000 07:099:00000 V - non linearity
+ YIBL  A    2 P 07:099:00000 00:000:00000 V - 
+ YSSK  A    1 P 00:000:00000 00:042:04020 P - receiver change
+ YSSK  A    2 P 00:042:04020 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ YSSK  A    3 P 03:268:71406 06:319:40458 P - EQ M8.3 - Kuril Islands
+ YSSK  A    4 P 06:319:40458 07:214:09462 P - EQ M6.2 - Tatar Strait, Russia
+ YSSK  A    5 P 07:214:09462 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ YSSK  A    6 P 11:070:20783 13:144:20689 P - EQ M8.3 - Sea of Okhotsk
+ YSSK  A    7 P 13:144:20689 00:000:00000 P - 
+ YSSK  A    1 P 00:000:00000 00:000:00000 V - 
+ ZAMB  A    1 P 00:000:00000 00:000:00000 P - 
+ ZAMB  A    1 P 00:000:00000 00:000:00000 V - 
+ ZECK  A    1 P 00:000:00000 01:193:46800 P - antenna change
+ ZECK  A    2 P 01:193:46800 06:211:00000 P - antenna change
+ ZECK  A    3 P 06:211:00000 11:230:43200 P - antenna change
+ ZECK  A    4 P 11:230:43200 00:000:00000 P - 
+ ZECK  A    1 P 00:000:00000 00:000:00000 V - 
+ ZIM2  A    1 P 00:000:00000 09:132:27000 P - antenna change
+ ZIM2  A    2 P 09:132:27000 13:283:43200 P - antenna change
+ ZIM2  A    3 P 13:283:43200 00:000:00000 P - 
+ ZIM2  A    1 P 00:000:00000 00:000:00000 V - 
+ ZIMM  A    1 P 00:000:00000 98:310:00000 P - antenna change
+ ZIMM  A    2 P 98:310:00000 00:000:00000 P - 
+ ZIMM  A    1 P 00:000:00000 00:000:00000 V - 
+*----------------------------------------------------------------
+ 0194  A    1 P 00:000:00000 03:160:00000 P - antenna change
+ 0194  A    2 P 03:160:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ 0194  A    3 P 03:268:71406 05:228:09988 P - EQ M7.2 - near the east coast of Honshu, Japan
+ 0194  A    4 P 05:228:09988 08:165:85425 P - EQ M6.9 - eastern Honshu, Japan
+ 0194  A    5 P 08:165:85425 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ 0194  A    6 P 11:070:20783 12:252:00000 P - unknown
+ 0194  A    7 P 12:252:00000 00:000:00000 P -
+ 0194  A    1 P 00:000:00000 03:268:71406 V - EQ M8.3 - Hokkaido, Japan region
+ 0194  A    2 P 03:268:71406 05:228:09988 V - EQ M7.2 - near the east coast of Honshu, Japan
+ 0194  A    3 P 05:228:09988 08:165:85425 V - EQ M6.9 - eastern Honshu, Japan
+ 0194  A    4 P 08:165:85425 00:000:00000 V -
+ AB07  A    1 P 00:000:00000 10:224:00000 P - non linearity
+ AB07  A    2 P 10:224:00000 12:097:00000 P - non linearity
+ AB07  A    3 P 12:097:00000 00:000:00000 P - 
+ AB07  A    1 P 00:000:00000 10:224:00000 V - non linearity
+ AB07  A    2 P 10:224:00000 12:097:00000 V - non linearity
+ AB07  A    3 P 12:097:00000 00:000:00000 V - 
+ AB09  A    1 P 00:000:00000 00:000:00000 P -
+ AB09  A    1 P 00:000:00000 00:000:00000 V -
+ AB11  A    1 P 00:000:00000 00:000:00000 P -
+ AB11  A    1 P 00:000:00000 00:000:00000 V -
+ AB21  A    1 P 00:000:00000 08:123:05617 P - EQ M6.6 - Andreanof Islands, Aleutian Islands, Alaska
+ AB21  A    2 P 08:123:05617 10:092:50460 P - antenna change
+ AB21  A    3 P 10:092:50460 10:246:40567 P - EQ M6.5 - Andreanof Islands, Aleutian Islands, Alaska
+ AB21  A    4 P 10:246:40567 13:242:59103 P - EQ M7.0 - 101km SW of Atka, Alaska
+ AB21  A    5 P 13:242:59103 00:000:00000 P -
+ AB21  A    1 P 00:000:00000 00:000:00000 V -
+ AB42  A    1 P 00:000:00000 07:282:00000 P - antenna change
+ AB42  A    2 P 07:282:00000 10:159:55800 P - antenna change
+ AB42  A    3 P 10:159:55800 00:000:00000 P -
+ AB42  A    1 P 00:000:00000 00:000:00000 V -
+ AB44  A    1 P 00:000:00000 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ AB44  A    2 P 13:005:32299 00:000:00000 P -
+ AB44  A    1 P 00:000:00000 00:000:00000 V -
+ AB50  A    1 P 00:000:00000 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ AB50  A    2 P 13:005:32299 00:000:00000 P -
+ AB50  A    1 P 00:000:00000 00:000:00000 V -
+ ABER  A    1 P 00:000:00000 10:204:00000 P - receiver change
+ ABER  A    2 P 10:204:00000 13:235:00000 P - antenna change
+ ABER  A    3 P 13:235:00000 13:301:32400 P - receiver change
+ ABER  A    4 P 13:301:32400 00:000:00000 P -
+ ABER  A    1 P 00:000:00000 00:000:00000 V -
+ AC15  A    1 P 00:000:00000 09:014:00000 P - non linearity
+ AC15  A    2 P 09:014:00000 11:162:00000 P - non linearity
+ AC15  A    3 P 11:162:00000 00:000:00000 P - 
+ AC15  A    1 P 00:000:00000 09:014:00000 V - non linearity
+ AC15  A    2 P 09:014:00000 11:162:00000 V - non linearity
+ AC15  A    3 P 11:162:00000 00:000:00000 V - 
+ ACOR  A    1 P 00:000:00000 00:008:00000 P - unknown
+ ACOR  A    2 P 00:008:00000 07:077:00000 P - antenna change
+ ACOR  A    3 P 07:077:00000 00:000:00000 P -
+ ACOR  A    1 P 00:000:00000 00:000:00000 V -
+ ACU6  A    1 P 00:000:00000 06:356:00000 P - unknown
+ ACU6  A    2 P 06:356:00000 00:000:00000 P -
+ ACU6  A    1 P 00:000:00000 00:000:00000 V -
+ ADE0  A    1 P 00:000:00000 07:333:68420 P - EQ M7.4 - Martinique region, Windward Islands
+ ADE0  A    2 P 07:333:68420 10:077:00000 P - unknown
+ ADE0  A    3 P 10:077:00000 00:000:00000 P -
+ ADE0  A    1 P 00:000:00000 00:000:00000 V -
+ ADE2  A    1 P 00:000:00000 00:000:00000 P -
+ ADE2  A    1 P 00:000:00000 00:000:00000 V -
+ AIRA  A    1 P 00:000:00000 03:050:32640 P - antenna change
+ AIRA  A    2 P 03:050:32640 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ AIRA  A    3 P 11:070:20783 12:214:03600 P - antenna change
+ AIRA  A    4 P 12:214:03600 16:112:00000 P - unknown mjia
+ AIRA  A    5 P 16:112:00000 00:000:00000 P -
+ AIRA  A    1 P 00:000:00000 00:000:00000 V -
+ AIS1  A    1 P 00:000:00000 96:325:00000 P - receiver change
+ AIS1  A    2 P 96:325:00000 05:111:00000 P - unknown
+ AIS1  A    3 P 05:111:00000 05:355:00000 P - unknown
+ AIS1  A    4 P 05:355:00000 00:000:00000 P -
+ AIS1  A    1 P 00:000:00000 00:000:00000 V -
+ AIS5  A    1 P 00:000:00000 08:226:00000 P - receiver change
+ AIS5  A    2 P 08:226:00000 12:302:11049 P - EQ M7.8 - Haida Gwaii, Canada
+ AIS5  A    3 P 12:302:11049 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ AIS5  A    4 P 13:005:32299 00:000:00000 P -
+ AIS5  A    1 P 00:000:00000 00:000:00000 V -
+ ALAC  A    1 P 00:000:00000 06:151:43200 P - antenna change
+ ALAC  A    2 P 06:151:43200 10:258:00000 P - antenna change
+ ALAC  A    3 P 10:258:00000 00:000:00000 P -
+ ALAC  A    1 P 00:000:00000 00:000:00000 V -
+ ALBY  A    1 P 00:000:00000 00:000:00000 P -
+ ALBY  A    1 P 00:000:00000 00:000:00000 V -
+ ALDI  A    1 P 00:000:00000 00:000:00000 P -
+ ALDI  A    1 P 00:000:00000 00:000:00000 V -
+ ALME  A    1 P 00:000:00000 07:036:68400 P - antenna change
+ ALME  A    2 P 07:036:68400 00:000:00000 P -
+ ALME  A    1 P 00:000:00000 00:000:00000 V -
+ ALON  A    1 P 00:000:00000 00:000:00000 P -
+ ALON  A    1 P 00:000:00000 00:000:00000 V -
+ AMBA  A    1 P 00:000:00000 00:000:00000 P -
+ AMBA  A    1 P 00:000:00000 00:000:00000 V -
+ AMBL  A    1 P 00:000:00000 00:000:00000 P -
+ AMBL  A    1 P 00:000:00000 00:000:00000 V -
+ AMMN  A    1 P 00:000:00000 99:237:00000 P - unknown
+ AMMN  A    2 P 99:237:00000 00:000:00000 P -
+ AMMN  A    1 P 00:000:00000 00:000:00000 V -
+ ANDE  A    1 P 00:000:00000 07:178:00000 P - unknown
+ ANDE  A    2 P 07:178:00000 09:248:00000 P - unknown
+ ANDE  A    3 P 09:248:00000 00:000:00000 P -
+ ANDE  A    1 P 00:000:00000 00:000:00000 V -
+ ANDO  A    1 P 00:000:00000 10:300:00000 P - unknown
+ ANDO  A    2 P 10:300:00000 00:000:00000 P -
+ ANDO  A    1 P 00:000:00000 00:000:00000 V -
+ ANG1  A    1 P 00:000:00000 04:156:00000 P - unknown
+ ANG1  A    2 P 04:156:00000 04:205:00000 P - unknown
+ ANG1  A    3 P 04:205:00000 00:000:00000 P -
+ ANG1  A    1 P 00:000:00000 00:000:00000 V -
+ ANKR  A    1 P 00:000:00000 97:205:00000 P - antenna change
+ ANKR  A    2 P 97:205:00000 98:259:00000 P - antenna change
+ ANKR  A    3 P 98:259:00000 99:229:00099 P - EQ M7.6 - western Turkey
+ ANKR  A    4 P 99:229:00099 99:316:61040 P - EQ M7.2 - western Turkey
+ ANKR  A    5 P 99:316:61040 00:329:00000 P - antenna change
+ ANKR  A    6 P 00:329:00000 08:127:39600 P - antenna change
+ ANKR  A    7 P 08:127:39600 11:094:00000 P - non linearity
+ ANKR  A    8 P 11:094:00000 17:179:00000 P - 
+ ANKR  A    9 P 17:179:00000 00:000:00000 P - 
+ ANKR  A    1 P 00:000:00000 11:094:00000 V - non linearity
+ ANKR  A    2 P 11:094:00000 00:000:00000 V - 
+ ANP1  A    1 P 00:000:00000 00:000:00000 P -
+ ANP1  A    1 P 00:000:00000 00:000:00000 V -
+ ANP5  A    1 P 00:000:00000 00:000:00000 P -
+ ANP5  A    1 P 00:000:00000 00:000:00000 V -
+ ANTC  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ ANTC  A    2 P 10:058:23652 00:000:00000 P -
+ ANTC  A    1 P 00:000:00000 00:000:00000 V -
+ ANTO  A    1 P 00:000:00000 00:000:00000 P -
+ ANTO  A    1 P 00:000:00000 00:000:00000 V -
+ AOA1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ AOA1  A    2 P 99:289:35204 00:000:00000 P -
+ AOA1  A    1 P 00:000:00000 00:000:00000 V -
+ ARGI  A    1 P 00:000:00000 00:000:00000 P -
+ ARGI  A    1 P 00:000:00000 00:000:00000 V -
+ ARP3  A    1 P 00:000:00000 98:248:00000 P - non linearity
+ ARP3  A    2 P 98:248:00000 99:237:00000 P - unknown
+ ARP3  A    3 P 99:237:00000 00:000:00000 P - 
+ ARP3  A    1 P 00:000:00000 98:248:00000 V - non linearity
+ ARP3  A    2 P 98:248:00000 99:237:00000 V - unknown
+ ARP3  A    3 P 99:237:00000 00:000:00000 V - 
+ ARP3  A    1 P 00:000:00000 00:000:00000 V -
+ ARP7  A    1 P 00:000:00000 00:000:00000 P -
+ ARP7  A    1 P 00:000:00000 00:000:00000 V -
+ ASHV  A    1 P 00:000:00000 00:000:00000 P -
+ ASHV  A    1 P 00:000:00000 00:000:00000 V -
+ ASPA  A    1 P 00:000:00000 08:275:00000 P - antenna change
+ ASPA  A    2 P 08:275:00000 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ ASPA  A    3 P 09:272:64091 00:000:00000 P -
+ ASPA  A    1 P 00:000:00000 09:272:64091 V - EQ M8.1 - Samoa Islands region
+ ASPA  A    2 P 09:272:64091 00:000:00000 V -
+ AUKT  A    1 P 00:000:00000 00:000:00000 P -
+ AUKT  A    1 P 00:000:00000 00:000:00000 V -
+ AUS5  A    1 P 00:000:00000 96:022:00000 P - antenna change
+ AUS5  A    2 P 96:022:00000 96:259:00000 P - antenna change
+ AUS5  A    3 P 96:259:00000 97:253:00000 P - unknown
+ AUS5  A    4 P 97:253:00000 98:252:00000 P - unknown
+ AUS5  A    5 P 98:252:00000 02:285:00000 P - antenna change
+ AUS5  A    6 P 02:285:00000 00:000:00000 P -
+ AUS5  A    1 P 00:000:00000 00:000:00000 V -
+ AUT1  A    1 P 00:000:00000 06:048:00000 P - receiver change
+ AUT1  A    2 P 06:048:00000 00:000:00000 P -
+ AUT1  A    1 P 00:000:00000 00:000:00000 V -
+ AUTF  A    1 P 00:000:00000 00:000:00000 P -
+ AUTF  A    1 P 00:000:00000 00:000:00000 V -
+ AV09  A    1 P 00:000:00000 00:000:00000 P -
+ AV09  A    1 P 00:000:00000 00:000:00000 V -
+ AVUN  A    1 P 00:000:00000 09:280:80331 P - EQ M7.8 - Santa Cruz Islands
+ AVUN  A    2 P 09:280:80331 00:000:00000 P -
+ AVUN  A    1 P 00:000:00000 00:000:00000 V -
+ BAIE  A    1 P 00:000:00000 00:000:00000 P -
+ BAIE  A    1 P 00:000:00000 00:000:00000 V -
+ BAKE  A    1 P 00:000:00000 09:348:00000 P - antenna change
+ BAKE  A    2 P 09:348:00000 00:000:00000 P -
+ BAKE  A    1 P 00:000:00000 00:000:00000 V -
+ BAKO  A    1 P 00:000:00000 98:038:00000 P - antenna change
+ BAKO  A    2 P 98:038:00000 99:263:00000 P - unknown
+ BAKO  A    3 P 99:263:00000 00:156:59306 P - EQ M7.9 - southern Sumatra, Indonesia
+ BAKO  A    4 P 00:156:59306 00:280:00000 P - antenna change
+ BAKO  A    5 P 00:280:00000 01:279:00000 P - antenna change
+ BAKO  A    6 P 01:279:00000 02:040:00000 P - antenna change
+ BAKO  A    7 P 02:040:00000 02:248:00000 P - unknown
+ BAKO  A    8 P 02:248:00000 06:198:29969 P - EQ M7.7 - south of Java, Indonesia
+ BAKO  A    9 P 06:198:29969 07:001:00000 P - antenna change
+ BAKO  A   10 P 07:001:00000 09:245:28501 P - EQ M7.0 - Java, Indonesia
+ BAKO  A   11 P 09:245:28501 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ BAKO  A   12 P 12:102:31117 00:000:00000 P -
+ BAKO  A    1 P 00:000:00000 00:000:00000 V -
+ BAKU  A    1 P 00:000:00000 00:000:00000 P -
+ BAKU  A    1 P 00:000:00000 00:000:00000 V -
+ BAMF  A    1 P 00:000:00000 05:242:00000 P - antenna change
+ BAMF  A    2 P 05:242:00000 00:000:00000 P -
+ BAMF  A    1 P 00:000:00000 00:000:00000 V -
+ BAN2  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ BAN2  A    2 P 04:361:03530 08:064:32400 P - antenna change
+ BAN2  A    3 P 08:064:32400 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ BAN2  A    4 P 12:102:31117 00:000:00000 P - 
+ BAN2  A    1 P 00:000:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ BAN2  A    2 P 04:361:03530 00:000:00000 V - 
+ BAR1  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ BAR1  A    2 P 10:094:81643 13:002:37860 P - antenna change
+ BAR1  A    3 P 13:002:37860 00:000:00000 P -
+ BAR1  A    1 P 00:000:00000 00:000:00000 V -
+ BAY1  A    1 P 00:000:00000 00:000:00000 P -
+ BAY1  A    1 P 00:000:00000 00:000:00000 V -
+ BAY2  A    1 P 00:000:00000 00:000:00000 P -
+ BAY2  A    1 P 00:000:00000 00:000:00000 V -
+ BCOV  A    1 P 00:000:00000 03:114:68400 P - antenna change
+ BCOV  A    2 P 03:114:68400 12:302:11049 P - EQ M7.8 - Haida Gwaii, Canada
+ BCOV  A    3 P 12:302:11049 00:000:00000 P -
+ BCOV  A    1 P 00:000:00000 00:000:00000 V -
+ BEA2  A    1 P 00:000:00000 00:000:00000 P -
+ BEA2  A    1 P 00:000:00000 00:000:00000 V -
+ BEAR  A    1 P 00:000:00000 04:084:00000 P - unknown
+ BEAR  A    2 P 04:084:00000 00:000:00000 P - 
+ BEAR  A    1 P 00:000:00000 00:000:00000 V - 
+ BELE  A    1 P 00:000:00000 07:107:00000 P - antenna change
+ BELE  A    2 P 07:107:00000 00:000:00000 P -
+ BELE  A    1 P 00:000:00000 00:000:00000 V -
+ BELL  A    1 P 00:000:00000 07:085:39360 P - antenna change
+ BELL  A    2 P 07:085:39360 00:000:00000 P -
+ BELL  A    1 P 00:000:00000 00:000:00000 V -
+ BHR2  A    1 P 00:000:00000 07:228:00000 P - unknown
+ BHR2  A    2 P 07:228:00000 00:000:00000 P - 
+ BHR2  A    1 P 00:000:00000 00:000:00000 V - 
+ BIAZ  A    1 P 00:000:00000 09:330:36000 P - antenna change
+ BIAZ  A    2 P 09:330:36000 00:000:00000 P -
+ BIAZ  A    1 P 00:000:00000 00:000:00000 V -
+ BILB  A    1 P 00:000:00000 00:000:00000 P -
+ BILB  A    1 P 00:000:00000 00:000:00000 V -
+ BIN1  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ BIN1  A    2 P 12:102:31117 00:000:00000 P -
+ BIN1  A    1 P 00:000:00000 00:000:00000 V -
+ BINT  A    1 P 00:000:00000 00:153:00000 P - unknown
+ BINT  A    2 P 00:153:00000 00:183:00000 P - unknown
+ BINT  A    3 P 00:183:00000 00:000:00000 P -
+ BINT  A    1 P 00:000:00000 00:000:00000 V -
+ BIS1  A    1 P 00:000:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ BIS1  A    2 P 02:307:79961 04:002:00000 P - unknown
+ BIS1  A    3 P 04:002:00000 00:000:00000 P - 
+ BIS1  A    1 P 00:000:00000 00:000:00000 V - 
+ BIS5  A    1 P 00:000:00000 12:034:00000 P - unknown
+ BIS5  A    2 P 12:034:00000 13:005:32299 P - EQ M7.5 - Southeastern Alaska
+ BIS5  A    3 P 13:005:32299 00:000:00000 P - 
+ BIS5  A    1 P 00:000:00000 13:005:32299 V - EQ M7.5 - Southeastern Alaska
+ BIS5  A    2 P 13:005:32299 00:000:00000 V - 
+ BLUF  A    1 P 00:000:00000 04:327:73584 P - EQ M7.1 - off the west coast of the South Island of New Zealand
+ BLUF  A    2 P 04:327:73584 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ BLUF  A    3 P 04:358:53944 07:273:19414 P - EQ M7.4 - Auckland Islands, New Zealand region
+ BLUF  A    4 P 07:273:19414 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ BLUF  A    5 P 09:196:33749 16:318:00000 P -
+ BLUF  A    6 P 16:318:00000 00:000:00000 P -
+ BLUF  A    1 P 00:000:00000 00:000:00000 V -
+ BLYT  A    1 P 00:000:00000 95:026:00000 P - unknown
+ BLYT  A    2 P 95:026:00000 95:215:00000 P - antenna change
+ BLYT  A    3 P 95:215:00000 99:289:35204 P - EQ M7.1 - Southern California
+ BLYT  A    4 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ BLYT  A    5 P 10:094:81643 00:000:00000 P -
+ BLYT  A    1 P 00:000:00000 00:000:00000 V -
+ BMHG  A    1 P 00:000:00000 10:264:54000 P - antenna change
+ BMHG  A    2 P 10:264:54000 00:000:00000 P -
+ BMHG  A    1 P 00:000:00000 00:000:00000 V -
+ BNDY  A    1 P 00:000:00000 00:000:00000 P -
+ BNDY  A    1 P 00:000:00000 00:000:00000 V -
+ BOAV  A    1 P 00:000:00000 00:000:00000 P -
+ BOAV  A    1 P 00:000:00000 00:000:00000 V -
+ BOGO  A    1 P 00:000:00000 01:229:48600 P - antenna change
+ BOGO  A    2 P 01:229:48600 14:354:00000 P - unknown
+ BOGO  A    3 P 14:354:00000 00:000:00000 P -
+ BOGO  A    1 P 00:000:00000 00:000:00000 V -
+ BOGT  A    1 P 00:000:00000 97:213:00000 P - receiver change
+ BOGT  A    2 P 97:213:00000 00:272:00000 P - receiver change
+ BOGT  A    3 P 00:272:00000 05:193:00000 P - antenna change
+ BOGT  A    4 P 05:193:00000 07:228:00000 P - antenna change
+ BOGT  A    5 P 07:228:00000 07:347:72000 P - antenna change
+ BOGT  A    6 P 07:347:72000 08:159:00000 P - antenna change
+ BOGT  A    7 P 08:159:00000 09:252:54000 P - antenna change
+ BOGT  A    8 P 09:252:54000 11:097:00000 P - unknown
+ BOGT  A    9 P 11:097:00000 00:000:00000 P -
+ BOGT  A    1 P 00:000:00000 05:193:00000 V - antenna change
+ BOGT  A    2 P 05:193:00000 07:228:00000 V - antenna change
+ BOGT  A    3 P 07:228:00000 11:097:00000 V - unknown
+ BOGT  A    4 P 11:097:00000 00:000:00000 V -
+ BOMJ  A    1 P 00:000:00000 97:282:00000 P - antenna change
+ BOMJ  A    2 P 97:282:00000 01:292:00000 P - unknown
+ BOMJ  A    3 P 01:292:00000 02:307:00000 P - unknown
+ BOMJ  A    4 P 02:307:00000 07:213:00000 P - antenna change
+ BOMJ  A    5 P 07:213:00000 00:000:00000 P -
+ BOMJ  A    1 P 00:000:00000 00:000:00000 V -
+ BORJ  A    1 P 00:000:00000 10:244:50400 P - antenna change
+ BORJ  A    2 P 10:244:50400 00:000:00000 P -
+ BORJ  A    1 P 00:000:00000 00:000:00000 V -
+ BORK  A    1 P 00:000:00000 03:153:44460 P - antenna change
+ BORK  A    2 P 03:153:44460 03:182:36120 P - antenna change
+ BORK  A    3 P 03:182:36120 00:000:00000 P -
+ BORK  A    1 P 00:000:00000 00:000:00000 V -
+ BRAN  A    1 P 00:000:00000 95:096:00000 P - antenna change
+ BRAN  A    2 P 95:096:00000 95:139:00000 P - antenna change
+ BRAN  A    3 P 95:139:00000 95:199:00000 P - antenna change
+ BRAN  A    4 P 95:199:00000 00:000:00000 P -
+ BRAN  A    1 P 00:000:00000 00:000:00000 V -
+ BRIB  A    1 P 00:000:00000 00:000:00000 P -
+ BRIB  A    1 P 00:000:00000 00:000:00000 V -
+ BRO1  A    1 P 00:000:00000 00:000:00000 P -
+ BRO1  A    1 P 00:000:00000 00:000:00000 V -
+ BRU1  A    1 P 00:000:00000 00:000:00000 P -
+ BRU1  A    1 P 00:000:00000 00:000:00000 V -
+ BUDP  A    1 P 00:000:00000 00:000:00000 P -
+ BUDP  A    1 P 00:000:00000 00:000:00000 V -
+ BUE1  A    1 P 00:000:00000 00:046:00000 P - unknown
+ BUE1  A    2 P 00:046:00000 00:098:00000 P - unknown
+ BUE1  A    3 P 00:098:00000 06:011:00000 P - unknown
+ BUE1  A    4 P 06:011:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ BUE1  A    5 P 10:058:23652 00:000:00000 P -
+ BUE1  A    1 P 00:000:00000 00:000:00000 V -
+ BUE2  A    1 P 00:000:00000 06:011:00000 P - unknown
+ BUE2  A    2 P 06:011:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ BUE2  A    3 P 10:058:23652 00:000:00000 P -
+ BUE2  A    1 P 00:000:00000 00:000:00000 V -
+ BUEN  A    1 P 00:000:00000 12:274:59496 P - EQ M7.3 - Colombia
+ BUEN  A    2 P 12:274:59496 00:000:00000 P -
+ BUEN  A    1 P 00:000:00000 00:000:00000 V -
+ BUR2  A    1 P 00:000:00000 00:000:00000 P -
+ BUR2  A    1 P 00:000:00000 00:000:00000 V -
+ BYSP  A    1 P 00:000:00000 00:000:00000 P -
+ BYSP  A    1 P 00:000:00000 00:000:00000 V -
+ CABL  A    1 P 00:000:00000 02:188:00000 P - antenna change
+ CABL  A    2 P 02:188:00000 05:166:10253 P - EQ M7.2 - off the coast of Northern California
+ CABL  A    3 P 05:166:10253 07:069:00000 P - antenna change
+ CABL  A    4 P 07:069:00000 14:069:19093 P - EQ M6.8 - 78km WNW of Ferndale, California
+ CABL  A    5 P 14:069:19093 00:000:00000 P -
+ CABL  A    1 P 00:000:00000 00:000:00000 V -
+ CACC  A    1 P 00:000:00000 00:000:00000 P -
+ CACC  A    1 P 00:000:00000 00:000:00000 V -
+ CAGS  A    1 P 00:000:00000 12:235:60900 P - antenna change
+ CAGS  A    2 P 12:235:60900 00:000:00000 P -
+ CAGS  A    1 P 00:000:00000 00:000:00000 V -
+ CALL  A    1 P 00:000:00000 00:000:00000 P -
+ CALL  A    1 P 00:000:00000 00:000:00000 V -
+ CAM2  A    1 P 00:000:00000 00:000:00000 P -
+ CAM2  A    1 P 00:000:00000 00:000:00000 V -
+ CANT  A    1 P 00:000:00000 03:317:00000 P - unknown
+ CANT  A    2 P 03:317:00000 07:033:36000 P - antenna change
+ CANT  A    3 P 07:033:36000 11:293:39600 P - antenna change
+ CANT  A    4 P 11:293:39600 00:000:00000 P -
+ CANT  A    1 P 00:000:00000 00:000:00000 V -
+ CARR  A    1 P 00:000:00000 00:000:00000 P -
+ CARR  A    1 P 00:000:00000 00:000:00000 V -
+ CART  A    1 P 00:000:00000 00:062:00000 P - receiver change
+ CART  A    2 P 00:062:00000 12:348:82800 P - antenna change
+ CART  A    3 P 12:348:82800 00:000:00000 P -
+ CART  A    1 P 00:000:00000 00:000:00000 V -
+ CASA  A    1 P 00:000:00000 94:166:00000 P - antenna change
+ CASA  A    2 P 94:166:00000 97:271:00000 P - unknown
+ CASA  A    3 P 97:271:00000 98:070:00000 P - unknown
+ CASA  A    4 P 98:070:00000 99:135:48131 P - EQ M5.6 - Central California
+ CASA  A    5 P 99:135:48131 02:235:00000 P - unknown
+ CASA  A    6 P 02:235:00000 03:231:00000 P - unknown
+ CASA  A    7 P 03:231:00000 00:000:00000 P -
+ CASA  A    1 P 00:000:00000 97:271:00000 V - unknown
+ CASA  A    2 P 97:271:00000 98:070:00000 V - unknown
+ CASA  A    3 P 98:070:00000 00:000:00000 V -
+ CASC  A    1 P 00:000:00000 99:271:00000 P - antenna change
+ CASC  A    2 P 99:271:00000 08:061:50400 P - antenna change
+ CASC  A    3 P 08:061:50400 00:000:00000 P -
+ CASC  A    1 P 00:000:00000 00:000:00000 V -
+ CASL  A    1 P 00:000:00000 00:000:00000 P -
+ CASL  A    1 P 00:000:00000 00:000:00000 V -
+ CAT1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ CAT1  A    2 P 99:289:35204 00:000:00000 P -
+ CAT1  A    1 P 00:000:00000 00:000:00000 V -
+ CAT2  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ CAT2  A    2 P 10:094:81643 00:000:00000 P -
+ CAT2  A    1 P 00:000:00000 00:000:00000 V -
+ CATA  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ CATA  A    2 P 10:058:23652 00:000:00000 P -
+ CATA  A    1 P 00:000:00000 00:000:00000 V -
+ CAYN  A    1 P 00:000:00000 00:000:00000 P -
+ CAYN  A    1 P 00:000:00000 00:000:00000 V -
+ CCJ2  A    1 P 00:000:00000 09:060:00000 P - antenna change
+ CCJ2  A    2 P 09:060:00000 10:355:62381 P - EQ M7.4 - Bonin Islands, Japan region
+ CCJ2  A    3 P 10:355:62381 12:053:00000 P - antenna change
+ CCJ2  A    4 P 12:053:00000 00:000:00000 P -
+ CCJ2  A    1 P 00:000:00000 00:000:00000 V -
+ CCJM  A    1 P 00:000:00000 01:056:84060 P - antenna change
+ CCJM  A    2 P 01:056:84060 08:058:24861 P - EQ M6.2 - Bonin Islands, Japan region
+ CCJM  A    3 P 08:058:24861 10:355:62381 P - EQ M7.4 - Bonin Islands, Japan region
+ CCJM  A    4 P 10:355:62381 00:000:00000 P -
+ CCJM  A    1 P 00:000:00000 08:058:24861 V - EQ M6.2 - Bonin Islands, Japan region
+ CCJM  A    2 P 08:058:24861 00:000:00000 V -
+ CCV3  A    1 P 00:000:00000 00:000:00000 P -
+ CCV3  A    1 P 00:000:00000 00:000:00000 V -
+ CCV6  A    1 P 00:000:00000 00:000:00000 P -
+ CCV6  A    1 P 00:000:00000 00:000:00000 V -
+ CEBR  A    1 P 00:000:00000 12:356:38400 P - antenna change
+ CEBR  A    2 P 12:356:38400 00:000:00000 P -
+ CEBR  A    1 P 00:000:00000 00:000:00000 V -
+ CEFE  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ CEFE  A    2 P 10:058:23652 00:000:00000 P -
+ CEFE  A    1 P 00:000:00000 00:000:00000 V -
+ CEU1  A    1 P 00:000:00000 00:000:00000 P -
+ CEU1  A    1 P 00:000:00000 00:000:00000 V -
+ CEUT  A    1 P 00:000:00000 05:070:00000 P - unknown
+ CEUT  A    2 P 05:070:00000 06:327:36000 P - receiver change
+ CEUT  A    3 P 06:327:36000 00:000:00000 P -
+ CEUT  A    1 P 00:000:00000 00:000:00000 V -
+ CHA1  A    1 P 00:000:00000 97:112:00000 P - unknown
+ CHA1  A    2 P 97:112:00000 00:000:00000 P -
+ CHA1  A    1 P 00:000:00000 00:000:00000 V -
+ CHAB  B    1 P 00:000:00000 95:228:00000 P - antenna change
+ CHAB  B    2 P 95:228:00000 96:100:00000 P - antenna change
+ CHAB  B    3 P 96:100:00000 00:000:00000 P -
+ CHAB  B    1 P 00:000:00000 00:000:00000 V -
+ CHB1  A    1 P 00:000:00000 00:000:00000 P -
+ CHB1  A    1 P 00:000:00000 00:000:00000 V -
+ CHET  A    1 P 00:000:00000 09:148:30285 P - EQ M7.3 - offshore Honduras
+ CHET  A    2 P 09:148:30285 00:000:00000 P -
+ CHET  A    1 P 00:000:00000 00:000:00000 V -
+ CHIN  A    1 P 00:000:00000 12:075:00000 P - antenna change
+ CHIN  A    2 P 12:075:00000 00:000:00000 P -
+ CHIN  A    1 P 00:000:00000 00:000:00000 V -
+ CHIZ  A    1 P 00:000:00000 00:000:00000 P -
+ CHIZ  A    1 P 00:000:00000 00:000:00000 V -
+ CHL1  A    1 P 00:000:00000 00:000:00000 P -
+ CHL1  A    1 P 00:000:00000 00:000:00000 V -
+ CHR1  A    1 P 00:000:00000 00:000:00000 P -
+ CHR1  A    1 P 00:000:00000 00:000:00000 V -
+ CHT1  A    1 P 00:000:00000 00:000:00000 P -
+ CHT1  A    1 P 00:000:00000 00:000:00000 V -
+ CHWK  A    1 P 00:000:00000 99:217:57480 P - antenna change
+ CHWK  A    2 P 99:217:57480 08:025:75600 P - antenna change
+ CHWK  A    3 P 08:025:75600 10:309:73800 P - antenna change
+ CHWK  A    4 P 10:309:73800 00:000:00000 P -
+ CHWK  A    1 P 00:000:00000 00:000:00000 V -
+ CIC1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ CIC1  A    2 P 99:289:35204 00:000:00000 P -
+ CIC1  A    1 P 00:000:00000 00:000:00000 V -
+ CICE  A    1 P 00:000:00000 00:000:00000 P -
+ CICE  A    1 P 00:000:00000 00:000:00000 V -
+ CIT1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ CIT1  A    2 P 99:289:35204 11:141:00000 P - unknown
+ CIT1  A    3 P 11:141:00000 12:312:86160 P - antenna change
+ CIT1  A    4 P 12:312:86160 00:000:00000 P -
+ CIT1  A    1 P 00:000:00000 00:000:00000 V -
+ CME1  A    1 P 00:000:00000 03:023:00000 P - unknown
+ CME1  A    2 P 03:023:00000 05:166:10253 P - EQ M7.2 - off the coast of Northern California
+ CME1  A    3 P 05:166:10253 06:075:00000 P - antenna change
+ CME1  A    4 P 06:075:00000 00:000:00000 P -
+ CME1  A    1 P 00:000:00000 00:000:00000 V -
+ CNC0  A    1 P 00:000:00000 09:148:30285 P - EQ M7.3 - offshore Honduras
+ CNC0  A    2 P 09:148:30285 00:000:00000 P -
+ CNC0  A    1 P 00:000:00000 00:000:00000 V -
+ CNCL  A    1 P 00:000:00000 00:069:00000 P - unknown
+ CNCL  A    2 P 00:069:00000 00:216:00000 P - antenna change
+ CNCL  A    3 P 00:216:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ CNCL  A    4 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ CNCL  A    5 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ CNCL  A    6 P 10:246:59748 00:000:00000 P -
+ CNCL  A    1 P 00:000:00000 00:000:00000 V -
+ CNNS  A    1 P 00:000:00000 13:075:00000 P - unknown
+ CNNS  A    2 P 13:075:00000 00:000:00000 P -
+ CNNS  A    1 P 00:000:00000 00:000:00000 V -
+ COLA  B    1 P 00:000:00000 03:160:00000 P - antenna change
+ COLA  B    2 P 03:160:00000 03:248:68400 P - antenna change
+ COLA  B    3 P 03:248:68400 05:292:00000 P - antenna change
+ COLA  B    4 P 05:292:00000 12:001:00000 P - unknown
+ COLA  B    5 P 12:001:00000 00:000:00000 P -
+ COLA  B    1 P 00:000:00000 00:000:00000 V -
+ COPO  A    1 P 00:000:00000 06:120:69437 P - EQ M6.7 - offshore Atacama, Chile
+ COPO  A    2 P 06:120:69437 09:164:00000 P - non linearity
+ COPO  A    3 P 09:164:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ COPO  A    4 P 10:058:23652 13:097:00000 P - unknown
+ COPO  A    5 P 13:097:00000 00:000:00000 P - 
+ COPO  A    1 P 00:000:00000 06:120:69437 V - EQ M6.7 - offshore Atacama, Chile
+ COPO  A    2 P 06:120:69437 09:164:00000 V - non linearity
+ COPO  A    3 P 09:164:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ COPO  A    4 P 10:058:23652 13:097:00000 V - unknown
+ COPO  A    5 P 13:097:00000 00:000:00000 V - 
+ CORC  A    1 P 00:000:00000 00:000:00000 P -
+ CORC  A    1 P 00:000:00000 00:000:00000 V -
+ CORV  A    1 P 00:000:00000 96:151:00000 P - antenna change
+ CORV  A    2 P 96:151:00000 98:064:00000 P - antenna change
+ CORV  A    3 P 98:064:00000 98:314:00000 P - antenna change
+ CORV  A    4 P 98:314:00000 00:000:00000 P -
+ CORV  A    1 P 00:000:00000 00:000:00000 V -
+ COSO  A    1 P 00:000:00000 96:120:00000 P - antenna change
+ COSO  A    2 P 96:120:00000 99:289:35204 P - EQ M7.1 - Southern California
+ COSO  A    3 P 99:289:35204 01:199:00000 P - unknown
+ COSO  A    4 P 01:199:00000 00:000:00000 P -
+ COSO  A    1 P 00:000:00000 00:000:00000 V -
+ COT1  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ COT1  A    2 P 10:094:81643 00:000:00000 P -
+ COT1  A    1 P 00:000:00000 00:000:00000 V -
+ COUD  A    1 P 00:000:00000 10:252:32400 P - antenna change
+ COUD  A    2 P 10:252:32400 00:000:00000 P -
+ COUD  A    1 P 00:000:00000 00:000:00000 V -
+ COVX  A    1 P 00:000:00000 11:160:50400 P - antenna change
+ COVX  A    2 P 11:160:50400 00:000:00000 P -
+ COVX  A    1 P 00:000:00000 00:000:00000 V -
+ COYQ  A    1 P 00:000:00000 07:111:64426 P - EQ M6.2 - Aisen, Chile
+ COYQ  A    2 P 07:111:64426 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ COYQ  A    3 P 10:058:23652 00:000:00000 P -
+ COYQ  A    1 P 00:000:00000 07:111:64426 V - EQ M6.2 - Aisen, Chile
+ COYQ  A    2 P 07:111:64426 00:000:00000 V -
+ CPXF  A    1 P 00:000:00000 07:273:64800 P - antenna change
+ CPXF  A    2 P 07:273:64800 00:000:00000 P -
+ CPXF  A    1 P 00:000:00000 00:000:00000 V -
+ CRAR  A    1 P 00:000:00000 02:011:00000 P - unknown
+ CRAR  A    2 P 02:011:00000 00:000:00000 P -
+ CRAR  A    1 P 00:000:00000 00:000:00000 V -
+ CRFP  A    1 P 00:000:00000 95:033:00000 P - antenna change
+ CRFP  A    2 P 95:033:00000 95:214:00000 P - antenna change
+ CRFP  A    3 P 95:214:00000 99:289:35204 P - EQ M7.1 - Southern California
+ CRFP  A    4 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ CRFP  A    5 P 10:094:81643 13:346:78900 P - antenna change
+ CRFP  A    6 P 13:346:78900 00:000:00000 P -
+ CRFP  A    1 P 00:000:00000 00:000:00000 V -
+ CRU1  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ CRU1  A    2 P 10:094:81643 00:000:00000 P -
+ CRU1  A    1 P 00:000:00000 00:000:00000 V -
+ CSAR  A    1 P 00:000:00000 00:000:00000 P -
+ CSAR  A    1 P 00:000:00000 00:000:00000 V -
+ CTGR  A    1 P 00:000:00000 13:156:60600 P - antenna change
+ CTGR  A    2 P 13:156:60600 13:177:53400 P - antenna change
+ CTGR  A    3 P 13:177:53400 00:000:00000 P -
+ CTGR  A    1 P 00:000:00000 00:000:00000 V -
+ CTPU  A    1 P 00:000:00000 13:303:49200 P - antenna change
+ CTPU  A    2 P 13:303:49200 00:000:00000 P -
+ CTPU  A    1 P 00:000:00000 00:000:00000 V -
+ CTWN  A    1 P 00:000:00000 10:343:00000 P - unknown
+ CTWN  A    2 P 10:343:00000 11:330:00000 P - unknown
+ CTWN  A    3 P 11:330:00000 00:000:00000 P -
+ CTWN  A    1 P 00:000:00000 00:000:00000 V -
+ CUCU  A    1 P 00:000:00000 00:000:00000 P -
+ CUCU  A    1 P 00:000:00000 00:000:00000 V -
+ CUIB  A    1 P 00:000:00000 01:174:73994 P - EQ M8.4 - near the coast of southern Peru
+ CUIB  A    2 P 01:174:73994 12:327:55200 P - antenna change
+ CUIB  A    3 P 12:327:55200 14:318:57900 P - antenna change
+ CUIB  A    4 P 14:318:57900 00:000:00000 P -
+ CUIB  A    1 P 00:000:00000 00:000:00000 V -
+ CUPR  A    1 P 00:000:00000 00:000:00000 P -
+ CUPR  A    1 P 00:000:00000 00:000:00000 V -
+ DA60  A    1 P 00:000:00000 06:169:00000 P - unknown
+ DA60  A    2 P 06:169:00000 00:000:00000 P -
+ DA60  A    1 P 00:000:00000 00:000:00000 V -
+ DAKA  B    1 P 00:000:00000 04:336:00000 P - antenna change
+ DAKA  B    2 P 04:336:00000 07:023:00000 P - antenna change
+ DAKA  B    3 P 07:023:00000 00:000:00000 P -
+ DAKA  B    1 P 00:000:00000 00:000:00000 V -
+ DARM  A    1 P 00:000:00000 00:000:00000 P -
+ DARM  A    1 P 00:000:00000 00:000:00000 V -
+ DARR  A    1 P 00:000:00000 01:292:00000 P - antenna change
+ DARR  A    2 P 01:292:00000 01:348:00000 P - antenna change
+ DARR  A    3 P 01:348:00000 03:094:03600 P - antenna change
+ DARR  A    4 P 03:094:03600 00:000:00000 P -
+ DARR  A    1 P 00:000:00000 00:000:00000 V -
+ DAVR  A    1 P 00:000:00000 07:213:21600 P - antenna change
+ DAVR  A    2 P 07:213:21600 00:000:00000 P -
+ DAVR  A    1 P 00:000:00000 00:000:00000 V -
+ DEAR  A    1 P 00:000:00000 00:000:00000 P -
+ DEAR  A    1 P 00:000:00000 00:000:00000 V -
+ DGLG  A    1 P 00:000:00000 07:051:00000 P - antenna change
+ DGLG  A    2 P 07:051:00000 00:000:00000 P -
+ DGLG  A    1 P 00:000:00000 00:000:00000 V -
+ DIPL  A    1 P 00:000:00000 10:266:50400 P - antenna change
+ DIPL  A    2 P 10:266:50400 00:000:00000 P -
+ DIPL  A    1 P 00:000:00000 00:000:00000 V -
+ DJOU  A    1 P 00:000:00000 00:000:00000 P -
+ DJOU  A    1 P 00:000:00000 00:000:00000 V -
+ DKSG  A    1 P 00:000:00000 00:000:00000 P -
+ DKSG  A    1 P 00:000:00000 00:000:00000 V -
+ DNRC  A    1 P 00:000:00000 08:151:00000 P - antenna change
+ DNRC  A    2 P 08:151:00000 00:000:00000 P -
+ DNRC  A    1 P 00:000:00000 00:000:00000 V -
+ DSEA  A    1 P 00:000:00000 00:000:00000 P -
+ DSEA  A    1 P 00:000:00000 00:000:00000 V -
+ DUND  A    1 P 00:000:00000 07:273:19414 P - EQ M7.4 - Auckland Islands, New Zealand region
+ DUND  A    2 P 07:273:19414 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ DUND  A    3 P 09:196:33749 10:328:84900 P - antenna change
+ DUND  A    4 P 10:328:84900 16:318:00000 P -
+ DUND  A    5 P 16:318:00000 19:275:00000 P -
+ DUND  A    6 P 19:275:00000 00:000:00000 P - unknow
+ DUND  A    1 P 00:000:00000 00:000:00000 V -
+ DUNT  A    1 P 00:000:00000 03:233:43970 P - EQ M7.2 - South Island of New Zealand
+ DUNT  A    2 P 03:233:43970 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ DUNT  A    3 P 04:358:53944 06:294:00000 P - unknown
+ DUNT  A    4 P 06:294:00000 06:357:00000 P - unknown
+ DUNT  A    5 P 06:357:00000 07:273:19414 P - EQ M7.4 - Auckland Islands, New Zealand region
+ DUNT  A    6 P 07:273:19414 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ DUNT  A    7 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ DUNT  A    8 P 10:246:59748 16:318:00000 P -
+ DUNT  A    9 P 16:318:00000 00:000:00000 P -
+ DUNT  A    1 P 00:000:00000 00:000:00000 V -
+ DWH1  A    1 P 00:000:00000 04:141:00000 P - non linearity
+ DWH1  A    2 P 04:141:00000 00:000:00000 P - 
+ DWH1  A    1 P 00:000:00000 04:141:00000 V - non linearity
+ DWH1  A    2 P 04:141:00000 00:000:00000 V - 
+ DYNG  A    1 P 00:000:00000 00:000:00000 P - 
+ DYNG  A    1 P 00:000:00000 00:000:00000 V - 
+ EDIN  A    1 P 00:000:00000 08:345:47400 P - antenna change
+ EDIN  A    2 P 08:345:47400 00:000:00000 P -
+ EDIN  A    1 P 00:000:00000 00:000:00000 V -
+ EIIV  A    1 P 00:000:00000 06:336:00000 P - non linearity
+ EIIV  A    2 P 06:336:00000 12:045:00000 P - unknown
+ EIIV  A    3 P 12:045:00000 00:000:00000 P - 
+ EIIV  A    1 P 00:000:00000 06:336:00000 V - non linearity
+ EIIV  A    2 P 06:336:00000 00:000:00000 V - 
+ EIL1  A    1 P 00:000:00000 99:253:00000 P - unknown
+ EIL1  A    2 P 99:253:00000 00:126:00000 P - unknown
+ EIL1  A    3 P 00:126:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ EIL1  A    4 P 02:307:79961 00:000:00000 P -
+ EIL1  A    1 P 00:000:00000 02:307:79961 V - EQ M7.9 - Central Alaska
+ EIL1  A    2 P 02:307:79961 00:000:00000 V -
+ ELAT  A    1 P 00:000:00000 04:336:00000 P - antenna change
+ ELAT  A    2 P 04:336:00000 11:002:00000 P - unknown
+ ELAT  A    3 P 11:002:00000 13:363:00000 P - unknown
+ ELAT  A    4 P 13:363:00000 00:000:00000 P -
+ ELAT  A    1 P 00:000:00000 00:000:00000 V -
+ ELEN  A    1 P 00:000:00000 09:148:30285 P - EQ M7.3 - offshore Honduras
+ ELEN  A    2 P 09:148:30285 12:172:00000 P - antenna change
+ ELEN  A    3 P 12:172:00000 00:000:00000 P -
+ ELEN  A    1 P 00:000:00000 00:000:00000 V -
+ ELRO  A    1 P 00:000:00000 00:000:00000 P -
+ ELRO  A    1 P 00:000:00000 00:000:00000 V -
+ ENG1  A    1 P 00:000:00000 00:000:00000 P -
+ ENG1  A    1 P 00:000:00000 00:000:00000 V -
+ EPRT  A    1 P 00:000:00000 99:266:00000 P - antenna change
+ EPRT  A    2 P 99:266:00000 00:251:00000 P - unknown
+ EPRT  A    3 P 00:251:00000 01:308:00000 P - unknown
+ EPRT  A    4 P 01:308:00000 02:031:00000 P - unknown
+ EPRT  A    5 P 02:031:00000 04:192:00000 P - antenna change
+ EPRT  A    6 P 04:192:00000 00:000:00000 P -
+ EPRT  A    1 P 00:000:00000 00:000:00000 V -
+ EQHE  A    1 P 00:000:00000 12:248:32400 P - antenna change
+ EQHE  A    2 P 12:248:32400 00:000:00000 P -
+ EQHE  A    1 P 00:000:00000 00:000:00000 V -
+ ESBC  A    1 P 00:000:00000 00:000:00000 P -
+ ESBC  A    1 P 00:000:00000 00:000:00000 V -
+ ESBH  A    1 P 00:000:00000 09:132:72000 P - antenna change
+ ESBH  A    2 P 09:132:72000 09:173:00000 P - unknown
+ ESBH  A    3 P 09:173:00000 00:000:00000 P -
+ ESBH  A    1 P 00:000:00000 00:000:00000 V -
+ ESCO  A    1 P 00:000:00000 00:000:00000 P -
+ ESCO  A    1 P 00:000:00000 00:000:00000 V -
+ ESCU  A    1 P 00:000:00000 13:296:64560 P - antenna change
+ ESCU  A    2 P 13:296:64560 00:000:00000 P -
+ ESCU  A    1 P 00:000:00000 00:000:00000 V -
+ ESPA  A    1 P 00:000:00000 16:063:00000 P -
+ ESPA  A    2 P 16:063:00000 00:000:00000 P - unknown mjia
+ ESPA  A    1 P 00:000:00000 00:000:00000 V -
+ ESPI  A    1 P 00:000:00000 00:000:00000 P -
+ ESPI  A    1 P 00:000:00000 00:000:00000 V -
+ ESTI  A    1 P 00:000:00000 00:256:00000 P - unknown
+ ESTI  A    2 P 00:256:00000 01:013:63212 P - EQ M7.7 - offshore El Salvador
+ ESTI  A    3 P 01:013:63212 00:000:00000 P -
+ ESPI  A    1 P 00:000:00000 00:000:00000 P -
+ ESPI  A    1 P 00:000:00000 00:000:00000 V -
+ ESTI  A    1 P 00:000:00000 00:256:00000 P - unknown
+ ESTI  A    2 P 00:256:00000 01:013:63212 P - EQ M7.7 - offshore El Salvador
+ ESTI  A    3 P 01:013:63212 00:000:00000 P -
+ ESTI  A    1 P 00:000:00000 00:000:00000 V -
+ ETAD  A    1 P 00:000:00000 00:000:00000 P -
+ ETAD  A    1 P 00:000:00000 00:000:00000 V -
+ EUR2  A    1 P 00:000:00000 06:201:00000 P - unknown
+ EUR2  A    2 P 06:201:00000 00:000:00000 P -
+ EUR2  A    1 P 00:000:00000 00:000:00000 V -
+ EURK  A    1 P 00:000:00000 03:119:00000 P - unknown
+ EURK  A    2 P 03:119:00000 00:000:00000 P -
+ EURK  A    1 P 00:000:00000 00:000:00000 V -
+ EXU0  A    1 P 00:000:00000 00:000:00000 P -
+ EXU0  A    1 P 00:000:00000 00:000:00000 V -
+ EYAC  A    1 P 00:000:00000 00:000:00000 P -
+ EYAC  A    1 P 00:000:00000 00:000:00000 V -
+ EZEV  A    1 P 00:000:00000 00:000:00000 P -
+ EZEV  A    1 P 00:000:00000 00:000:00000 V -
+ FAIV  A    1 P 00:000:00000 15:015:68940 P - receiver change
+ FAIV  A    2 P 15:015:68940 00:000:00000 P -
+ FAIV  A    1 P 00:000:00000 00:000:00000 V -
+ FALE  A    1 P 00:000:00000 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ FALE  A    2 P 09:272:64091 10:295:10200 P - antenna change
+ FALE  A    3 P 10:295:10200 00:000:00000 P -
+ FALE  A    1 P 00:000:00000 09:272:64091 V - EQ M8.1 - Samoa Islands region
+ FALE  A    2 P 09:272:64091 00:000:00000 V -
+ FARB  A    1 P 00:000:00000 97:081:00000 P - antenna change
+ FARB  A    2 P 97:081:00000 11:339:00000 P - antenna change
+ FARB  A    3 P 11:339:00000 00:000:00000 P - 
+ FARB  A    1 P 00:000:00000 97:081:00000 V - antenna change
+ FARB  A    2 P 97:081:00000 00:000:00000 V - 
+ FERR  A    1 P 00:000:00000 00:000:00000 P -
+ FERR  A    1 P 00:000:00000 00:000:00000 V -
+ FG07  A    1 P 00:000:00000 11:264:00000 P - unknown
+ FG07  A    2 P 11:264:00000 00:000:00000 P -
+ FG07  A    1 P 00:000:00000 00:000:00000 V -
+ FG08  A    1 P 00:000:00000 13:198:00000 P - unknown
+ FG08  A    2 P 13:198:00000 00:000:00000 P -
+ FG08  A    1 P 00:000:00000 00:000:00000 V -
+ FLIU  A    1 P 00:000:00000 00:000:00000 P -
+ FLIU  A    1 P 00:000:00000 00:000:00000 V -
+ FLM5  A    1 P 00:000:00000 00:000:00000 P -
+ FLM5  A    1 P 00:000:00000 00:000:00000 V -
+ FMTS  A    1 P 00:000:00000 13:064:00000 P - unknown
+ FMTS  A    2 P 13:064:00000 00:000:00000 P -
+ FMTS  A    1 P 00:000:00000 00:000:00000 V -
+ FNA0  A    1 P 00:000:00000 05:045:65159 P - EQ M5.8 - Guadeloupe region, Leeward Islands
+ FNA0  A    2 P 05:045:65159 07:333:68420 P - EQ M7.4 - Martinique region, Windward Islands
+ FNA0  A    3 P 07:333:68420 09:365:00000 P - unknown
+ FNA0  A    4 P 09:365:00000 00:000:00000 P -
+ FNA0  A    1 P 00:000:00000 00:000:00000 V -
+ FOYL  A    1 P 00:000:00000 00:000:00000 P -
+ FOYL  A    1 P 00:000:00000 00:000:00000 V -
+ FRDN  A    1 P 00:000:00000 04:191:57600 P - antenna change
+ FRDN  A    2 P 04:191:57600 06:212:52800 P - antenna change
+ FRDN  A    3 P 06:212:52800 09:355:00000 P - antenna change
+ FRDN  A    4 P 09:355:00000 00:000:00000 P -
+ FRDN  A    1 P 00:000:00000 00:000:00000 V -
+ FREI  A    1 P 00:000:00000 00:000:00000 P -
+ FREI  A    1 P 00:000:00000 00:000:00000 V -
+ FTNA  A    1 P 00:000:00000 05:347:11766 P - EQ M6.7 - Fiji region
+ FTNA  A    2 P 05:347:11766 06:123:55600 P - EQ M8.0 - Tonga
+ FTNA  A    3 P 06:123:55600 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ FTNA  A    4 P 09:272:64091 12:141:28800 P - antenna change
+ FTNA  A    5 P 12:141:28800 00:000:00000 P -
+ FTNA  A    1 P 00:000:00000 00:000:00000 V -
+ FTP4  A    1 P 00:000:00000 00:000:00000 P -
+ FTP4  A    1 P 00:000:00000 00:000:00000 V -
+ FTS1  A    1 P 00:000:00000 00:000:00000 P -
+ FTS1  A    1 P 00:000:00000 00:000:00000 V -
+ FTS5  A    1 P 00:000:00000 00:000:00000 P -
+ FTS5  A    1 P 00:000:00000 00:000:00000 V -
+ GAIA  A    1 P 00:000:00000 02:206:57600 P - receiver change
+ GAIA  A    2 P 02:206:57600 12:155:00000 P - unknown
+ GAIA  A    3 P 12:155:00000 00:000:00000 P -
+ GAIA  A    1 P 00:000:00000 00:000:00000 V -
+ GAIT  A    1 P 00:000:00000 00:000:00000 P -
+ GAIT  A    1 P 00:000:00000 00:000:00000 V -
+ GAL1  A    1 P 00:000:00000 00:000:00000 P -
+ GAL1  A    1 P 00:000:00000 00:000:00000 V -
+ GALA  B    1 P 00:000:00000 97:052:00000 P - unknown
+ GALA  B    2 P 97:052:00000 00:000:00000 P -
+ GALA  B    1 P 00:000:00000 00:000:00000 V -
+ GAMB  A    1 P 00:000:00000 00:000:00000 P -
+ GAMB  A    1 P 00:000:00000 00:000:00000 V -
+ GAO1  A    1 P 00:000:00000 00:000:00000 P -
+ GAO1  A    1 P 00:000:00000 00:000:00000 V -
+ GARI  A    1 P 00:000:00000 00:000:00000 P -
+ GARI  A    1 P 00:000:00000 00:000:00000 V -
+ GASK  A    1 P 00:000:00000 12:018:00000 P - antenna change
+ GASK  A    2 P 12:018:00000 12:048:00000 P - antenna change
+ GASK  A    3 P 12:048:00000 00:000:00000 P -
+ GASK  A    1 P 00:000:00000 00:000:00000 V -
+ GCGT  A    1 P 00:000:00000 00:000:00000 P -
+ GCGT  A    1 P 00:000:00000 00:000:00000 V -
+ GENO  A    1 P 00:000:00000 00:000:00000 P -
+ GENO  A    1 P 00:000:00000 00:000:00000 V -
+ GESR  A    1 P 00:000:00000 00:000:00000 P -
+ GESR  A    1 P 00:000:00000 00:000:00000 V -
+ GETI  A    1 P 00:000:00000 00:153:00000 P - unknown
+ GETI  A    2 P 00:153:00000 00:183:00000 P - unknown
+ GETI  A    3 P 00:183:00000 00:000:00000 P -
+ GETI  A    1 P 00:000:00000 00:000:00000 V -
+ GIBR  A    1 P 00:000:00000 10:172:00000 P - unknown
+ GIBR  A    2 P 10:172:00000 10:188:00000 P - antenna change
+ GIBR  A    3 P 10:188:00000 00:000:00000 P -
+ GIBR  A    1 P 00:000:00000 00:000:00000 V -
+ GILB  A    1 P 00:000:00000 00:132:00000 P - antenna change
+ GILB  A    2 P 00:132:00000 00:000:00000 P -
+ GILB  A    1 P 00:000:00000 00:000:00000 V -
+ GLPT  A    1 P 00:000:00000 97:273:57600 P - antenna change
+ GLPT  A    2 P 97:273:57600 00:000:00000 P -
+ GLPT  A    1 P 00:000:00000 00:000:00000 V -
+ GMSD  A    1 P 00:000:00000 05:025:00000 P - unknown
+ GMSD  A    2 P 05:025:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ GMSD  A    3 P 11:070:20783 17:165:00000 P -
+ GMSD  A    4 P 17:165:00000 19:001:00000 P - EQ Japan
+ GMSD  A    5 P 19:001:00000 00:000:00000 P -
+ GMSD  A    1 P 00:000:00000 00:000:00000 V -
+ GODN  A    1 P 00:000:00000 00:000:00000 P -
+ GODN  A    1 P 00:000:00000 00:000:00000 V -
+ GODS  A    1 P 00:000:00000 00:000:00000 P -
+ GODS  A    1 P 00:000:00000 00:000:00000 V -
+ GOPE  A    1 P 00:000:00000 99:308:46800 P - antenna change
+ GOPE  A    2 P 99:308:46800 00:206:61320 P - antenna change
+ GOPE  A    3 P 00:206:61320 00:278:41400 P - antenna change
+ GOPE  A    4 P 00:278:41400 06:195:46200 P - antenna change
+ GOPE  A    5 P 06:195:46200 09:348:37800 P - antenna change
+ GOPE  A    6 P 09:348:37800 00:000:00000 P -
+ GOPE  A    1 P 00:000:00000 00:000:00000 V -
+ GOSH  A    1 P 00:000:00000 99:212:00000 P - antenna change
+ GOSH  A    2 P 99:212:00000 00:000:00000 P -
+ GOSH  A    1 P 00:000:00000 00:000:00000 V -
+ GRIS  A    1 P 00:000:00000 13:345:68160 P - antenna change
+ GRIS  A    2 P 13:345:68160 00:000:00000 P -
+ GRIS  A    1 P 00:000:00000 00:000:00000 V -
+ GROI  A    1 P 00:000:00000 04:161:36000 P - antenna change
+ GROI  A    2 P 04:161:36000 00:000:00000 P -
+ GROI  A    1 P 00:000:00000 00:000:00000 V -
+ GUAX  A    1 P 00:000:00000 00:000:00000 P -
+ GUAX  A    1 P 00:000:00000 00:000:00000 V -
+ GUIP  A    1 P 00:000:00000 08:295:00000 P - antenna change
+ GUIP  A    2 P 08:295:00000 12:290:28800 P - antenna change
+ GUIP  A    3 P 12:290:28800 00:000:00000 P -
+ GUIP  A    1 P 00:000:00000 00:000:00000 V -
+ GUS2  A    1 P 00:000:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ GUS2  A    2 P 02:307:79961 00:000:00000 P -
+ GUS2  A    1 P 00:000:00000 00:000:00000 V -
+ HALY  A    1 P 00:000:00000 00:000:00000 P -
+ HALY  A    1 P 00:000:00000 00:000:00000 V -
+ HAMM  A    1 P 00:000:00000 11:278:00000 P - antenna change
+ HAMM  A    2 P 11:278:00000 00:000:00000 P -
+ HAMM  A    1 P 00:000:00000 00:000:00000 V -
+ HARK  A    1 P 00:000:00000 99:152:00000 P - antenna change
+ HARK  A    2 P 99:152:00000 00:000:00000 P -
+ HARK  A    1 P 00:000:00000 00:000:00000 V -
+ HARV  A    1 P 00:000:00000 95:293:00000 P - unknown
+ HARV  A    2 P 95:293:00000 99:253:00000 P - receiver change
+ HARV  A    3 P 99:253:00000 08:161:00000 P - unknown
+ HARV  A    4 P 08:161:00000 11:073:00000 P - unknown
+ HARV  A    5 P 11:073:00000 13:152:00000 P - unknown
+ HARV  A    6 P 13:152:00000 00:000:00000 P - 
+ HARV  A    1 P 00:000:00000 95:293:00000 V - unknown
+ HARV  A    2 P 95:293:00000 99:253:00000 V - receiver change
+ HARV  A    3 P 99:253:00000 08:161:00000 V - unknown
+ HARV  A    4 P 08:161:00000 00:000:00000 V - 
+ HEAU  A    1 P 00:000:00000 00:000:00000 P -
+ HEAU  A    1 P 00:000:00000 00:000:00000 V -
+ HELG  A    1 P 00:000:00000 00:000:00000 P -
+ HELG  A    1 P 00:000:00000 00:000:00000 V -
+ HELJ  A    1 P 00:000:00000 00:000:00000 P -
+ HELJ  A    1 P 00:000:00000 00:000:00000 V -
+ HER2  A    1 P 00:000:00000 12:103:26149 P - EQ M7.0 - Baja California, Mexico
+ HER2  A    2 P 12:103:26149 00:000:00000 P -
+ HER2  A    1 P 00:000:00000 00:000:00000 V -
+ HFLK  A    1 P 00:000:00000 99:301:45900 P - antenna change
+ HFLK  A    2 P 99:301:45900 04:015:37800 P - antenna change
+ HFLK  A    3 P 04:015:37800 00:000:00000 P -
+ HFLK  A    1 P 00:000:00000 00:000:00000 V -
+ HIL1  A    1 P 00:000:00000 02:173:22800 P - antenna change
+ HIL1  A    2 P 02:173:22800 03:198:00000 P - antenna change
+ HIL1  A    3 P 03:198:00000 04:315:03600 P - antenna change
+ HIL1  A    4 P 04:315:03600 06:222:00000 P - antenna change
+ HIL1  A    5 P 06:222:00000 00:000:00000 P -
+ HIL1  A    1 P 00:000:00000 00:000:00000 V -
+ HILO  A    1 P 00:000:00000 06:288:61669 P - EQ M6.7 - Hawaii region, Hawaii
+ HILO  A    2 P 06:288:61669 00:000:00000 P -
+ HILO  A    1 P 00:000:00000 00:000:00000 V -
+ HIRS  A    1 P 00:000:00000 00:000:00000 P -
+ HIRS  A    1 P 00:000:00000 00:000:00000 V -
+ HKLO  A    1 P 00:000:00000 00:000:00000 P -
+ HKLO  A    1 P 00:000:00000 00:000:00000 V -
+ HNIS  A    1 P 00:000:00000 18:108:00000 P - unknown
+ HNIS  A    2 P 18:108:00000 00:000:00000 P -
+ HNIS  A    1 P 00:000:00000 00:000:00000 V -
+ HNPT  A    1 P 00:000:00000 99:026:00000 P - antenna change
+ HNPT  A    2 P 99:026:00000 00:143:48120 P - antenna change
+ HNPT  A    3 P 00:143:48120 02:301:00000 P - non linearity
+ HNPT  A    4 P 02:301:00000 07:165:00000 P - antenna change
+ HNPT  A    5 P 07:165:00000 00:000:00000 P - 
+ HNPT  A    1 P 00:000:00000 02:301:00000 V - non linearity
+ HNPT  A    2 P 02:301:00000 07:165:00000 V - antenna change
+ HNPT  A    3 P 07:165:00000 00:000:00000 V - 
+ HNUS  A    1 P 00:000:00000 00:000:00000 P -
+ HNUS  A    1 P 00:000:00000 00:000:00000 V -
+ HOE2  A    1 P 00:000:00000 10:293:23400 P - antenna change
+ HOE2  A    2 P 10:293:23400 00:000:00000 P -
+ HOE2  A    1 P 00:000:00000 00:000:00000 V -
+ HOL2  A    1 P 00:000:00000 13:268:56700 P - antenna change
+ HOL2  A    2 P 13:268:56700 00:000:00000 P -
+ HOL2  A    1 P 00:000:00000 00:000:00000 V -
+ HOLC  A    1 P 00:000:00000 95:146:00000 P - antenna change
+ HOLC  A    2 P 95:146:00000 00:000:00000 P -
+ HOLC  A    1 P 00:000:00000 00:000:00000 V -
+ HOLY  A    1 P 00:000:00000 09:043:43200 P - antenna change
+ HOLY  A    2 P 09:043:43200 00:000:00000 P -
+ HOLY  A    1 P 00:000:00000 00:000:00000 V -
+ HOPB  A    1 P 00:000:00000 97:252:01980 P - antenna change
+ HOPB  A    2 P 97:252:01980 99:216:74280 P - antenna change
+ HOPB  A    3 P 99:216:74280 00:000:00000 P -
+ HOPB  A    1 P 00:000:00000 00:000:00000 V -
+ HORN  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ HORN  A    2 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ HORN  A    3 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ HORN  A    4 P 10:246:59748 00:000:00000 P -
+ HORN  A    1 P 00:000:00000 00:000:00000 V -
+ HOUE  A    1 P 00:000:00000 04:326:42068 P - EQ M6.3 - Dominica region, Leeward Islands
+ HOUE  A    2 P 04:326:42068 00:000:00000 P -
+ HOUE  A    1 P 00:000:00000 00:000:00000 V -
+ HOUS  A    1 P 00:000:00000 00:000:00000 P -
+ HOUS  A    1 P 00:000:00000 00:000:00000 V -
+ HRM1  A    1 P 00:000:00000 00:000:00000 P -
+ HRM1  A    1 P 00:000:00000 00:000:00000 V -
+ HUEL  A    1 P 00:000:00000 00:000:00000 P -
+ HUEL  A    1 P 00:000:00000 00:000:00000 V -
+ HUTB  A    1 P 00:000:00000 08:179:42014 P - EQ M6.6 - Andaman Islands, India region
+ HUTB  A    2 P 08:179:42014 10:163:70011 P - EQ M7.5 - Nicobar Islands, India region
+ HUTB  A    3 P 10:163:70011 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ HUTB  A    4 P 12:102:31117 00:000:00000 P -
+ HUTB  A    1 P 00:000:00000 00:000:00000 V -
+ IBIZ  A    1 P 00:000:00000 09:055:00000 P - unknown
+ IBIZ  A    2 P 09:055:00000 09:175:00000 P - unknown
+ IBIZ  A    3 P 09:175:00000 00:000:00000 P -
+ IBIZ  A    1 P 00:000:00000 00:000:00000 V -
+ ICAM  A    1 P 00:000:00000 09:148:30285 P - EQ M7.3 - offshore Honduras
+ ICAM  A    2 P 09:148:30285 00:000:00000 P -
+ ICAM  A    1 P 00:000:00000 00:000:00000 V -
+ IDDR  A    1 P 00:000:00000 00:000:00000 P -
+ IDDR  A    1 P 00:000:00000 00:000:00000 V -
+ IENG  A    1 P 00:000:00000 00:000:00000 P -
+ IENG  A    1 P 00:000:00000 00:000:00000 V -
+ IFRN  A    1 P 00:000:00000 00:000:00000 P -
+ IFRN  A    1 P 00:000:00000 00:000:00000 V -
+ IGM1  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ IGM1  A    2 P 10:058:23652 00:000:00000 P -
+ IGM1  A    1 P 00:000:00000 00:000:00000 V -
+ IID2  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ IID2  A    2 P 99:289:35204 00:280:00000 P - antenna change
+ IID2  A    3 P 00:280:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ IID2  A    4 P 10:094:81643 00:000:00000 P -
+ IID2  A    1 P 00:000:00000 00:000:00000 V -
+ IJMU  A    1 P 00:000:00000 00:000:00000 P -
+ IJMU  A    1 P 00:000:00000 00:000:00000 V -
+ ILHA  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ ILHA  A    2 P 10:058:23652 10:263:00000 P - antenna change
+ ILHA  A    3 P 10:263:00000 00:000:00000 P -
+ ILHA  A    1 P 00:000:00000 00:000:00000 V -
+ IMBT  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ IMBT  A    2 P 10:058:23652 13:276:00000 P - unknown
+ IMBT  A    3 P 13:276:00000 00:000:00000 P -
+ IMBT  A    1 P 00:000:00000 00:000:00000 V -
+ IMPZ  A    1 P 00:000:00000 00:130:00000 P - antenna change
+ IMPZ  A    2 P 00:130:00000 07:142:00000 P - antenna change
+ IMPZ  A    3 P 07:142:00000 12:311:00000 P - unknown
+ IMPZ  A    4 P 12:311:00000 00:000:00000 P -
+ IMPZ  A    1 P 00:000:00000 00:000:00000 V -
+ INEG  A    1 P 00:000:00000 00:037:00000 P - antenna change
+ INEG  A    2 P 00:037:00000 03:022:07595 P - EQ M7.6 - offshore Colima, Mexico
+ INEG  A    3 P 03:022:07595 09:017:00000 P - unknown
+ INEG  A    4 P 09:017:00000 00:000:00000 P -
+ INEG  A    1 P 00:000:00000 03:022:07595 V - EQ M7.6 - offshore Colima, Mexico
+ INEG  A    2 P 03:022:07595 00:000:00000 V -
+ IPAZ  A    1 P 00:000:00000 00:000:00000 P -
+ IPAZ  A    1 P 00:000:00000 00:000:00000 V -
+ IQQE  A    1 P 00:000:00000 05:164:81874 P - EQ M7.8 - Tarapaca, Chile
+ IQQE  A    2 P 05:164:81874 08:035:61291 P - EQ M6.3 - Tarapaca, Chile
+ IQQE  A    3 P 08:035:61291 14:091:85607 P - EQ M8.2 - 94km NW of Iquique, Chile
+ IQQE  A    4 P 14:091:85607 14:093:09791 P - EQ M7.7 - 53km SW of Iquique, Chile
+ IQQE  A    5 P 14:093:09791 00:000:00000 P -
+ IQQE  A    1 P 00:000:00000 05:164:81874 V - EQ M7.8 - Tarapaca, Chile
+ IQQE  A    2 P 05:164:81874 00:000:00000 V -
+ IQUI  A    1 P 00:000:00000 00:000:00000 P -
+ IQUI  A    1 P 00:000:00000 00:000:00000 V -
+ IRKJ  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ IRKJ  A    2 P 11:070:20783 00:000:00000 P -
+ IRKJ  A    1 P 00:000:00000 00:000:00000 V -
+ ISTA  A    1 P 00:000:00000 00:000:00000 P -
+ ISTA  A    1 P 00:000:00000 00:000:00000 V -
+ JAB1  A    1 P 00:000:00000 98:155:00000 P - receiver change
+ JAB1  A    2 P 98:155:00000 00:056:14400 P - antenna change
+ JAB1  A    3 P 00:056:14400 01:008:10800 P - antenna change
+ JAB1  A    4 P 01:008:10800 02:159:00000 P - antenna change
+ JAB1  A    5 P 02:159:00000 03:063:20100 P - antenna change
+ JAB1  A    6 P 03:063:20100 03:323:00000 P - receiver change
+ JAB1  A    7 P 03:323:00000 05:012:25140 P - antenna change
+ JAB1  A    8 P 05:012:25140 07:053:00000 P - antenna change
+ JAB1  A    9 P 07:053:00000 07:333:00000 P - antenna change
+ JAB1  A   10 P 07:333:00000 00:000:00000 P -
+ JAB1  A    1 P 00:000:00000 00:000:00000 V -
+ JAB2  A    1 P 00:000:00000 08:333:00000 P - antenna change
+ JAB2  A    2 P 08:333:00000 16:084:00000 P - unknown mjia
+ JAB2  A    3 P 16:084:00000 00:000:00000 P -
+ JAB2  A    1 P 00:000:00000 00:000:00000 V -
+ JAMA  A    1 P 00:000:00000 06:167:00000 P - receiver change
+ JAMA  A    2 P 06:167:00000 00:000:00000 P -
+ JAMA  A    1 P 00:000:00000 00:000:00000 V -
+ JASK  A    1 P 00:000:00000 13:106:38660 P - EQ M7.7 - 83km E of Khash, Iran
+ JASK  A    2 P 13:106:38660 13:267:41388 P - EQ M7.7 - 61km NNE of Awaran, Pakistan
+ JASK  A    3 P 13:267:41388 00:000:00000 P -
+ JASK  A    1 P 00:000:00000 00:000:00000 V -
+ JIZN  A    1 P 00:000:00000 00:000:00000 P -
+ JIZN  A    1 P 00:000:00000 00:000:00000 V -
+ JOEN  A    1 P 00:000:00000 00:000:00000 P -
+ JOEN  A    1 P 00:000:00000 00:000:00000 V -
+ JOZ2  A    1 P 00:000:00000 08:074:36600 P - antenna change
+ JOZ2  A    2 P 08:074:36600 00:000:00000 P -
+ JOZ2  A    1 P 00:000:00000 00:000:00000 V -
+ JPLM  A    1 P 00:000:00000 94:017:45055 P - EQ M6.7 - Greater Los Angeles area, California
+ JPLM  A    2 P 94:017:45055 94:165:00000 P - antenna change
+ JPLM  A    3 P 94:165:00000 99:289:35204 P - EQ M7.1 - Southern California
+ JPLM  A    4 P 99:289:35204 04:302:00000 P - non linearity
+ JPLM  A    5 P 04:302:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ JPLM  A    6 P 10:094:81643 00:000:00000 P - 
+ JPLM  A    1 P 00:000:00000 99:289:35204 V - EQ M7.1 - Southern California
+ JPLM  A    2 P 99:289:35204 04:302:00000 V - non linearity
+ JPLM  A    3 P 04:302:00000 10:094:81643 V - EQ M7.2 - Baja California, Mexico
+ JPLM  A    4 P 10:094:81643 00:000:00000 V - 
+ JPLV  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ JPLV  A    2 P 10:094:81643 00:000:00000 P - 
+ JPLV  A    1 P 00:000:00000 10:094:81643 V - EQ M7.2 - Baja California, Mexico
+ JPLV  A    2 P 10:094:81643 00:000:00000 V - 
+ JSLM  A    1 P 00:000:00000 00:000:00000 P -
+ JSLM  A    1 P 00:000:00000 00:000:00000 V -
+ JXVL  A    1 P 00:000:00000 13:317:03600 P - antenna change
+ JXVL  A    2 P 13:317:03600 00:000:00000 P -
+ JXVL  A    1 P 00:000:00000 00:000:00000 V -
+ KABR  A    1 P 00:000:00000 00:134:00000 P - antenna change
+ KABR  A    2 P 00:134:00000 00:000:00000 P -
+ KABR  A    1 P 00:000:00000 00:000:00000 V -
+ KARA  A    1 P 00:000:00000 00:070:00000 P - unknown
+ KARA  A    2 P 00:070:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ KARA  A    3 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ KARA  A    4 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ KARA  A    5 P 10:246:59748 00:000:00000 P -
+ KARA  A    1 P 00:000:00000 00:000:00000 V -
+ KARL  A    1 P 00:000:00000 02:184:36000 P - antenna change
+ KARL  A    2 P 02:184:36000 12:060:36000 P - antenna change
+ KARL  A    3 P 12:060:36000 00:000:00000 P -
+ KARL  A    1 P 00:000:00000 00:000:00000 V -
+ KAT2  A    1 P 00:000:00000 00:000:00000 P -
+ KAT2  A    1 P 00:000:00000 00:000:00000 V -
+ KATC  A    1 P 00:000:00000 00:000:00000 P -
+ KATC  A    1 P 00:000:00000 00:000:00000 V -
+ KATZ  A    1 P 00:000:00000 03:067:00000 P - unknown
+ KATZ  A    2 P 03:067:00000 04:301:00000 P - antenna change
+ KATZ  A    3 P 04:301:00000 00:000:00000 P - 
+ KATZ  A    1 P 00:000:00000 03:067:00000 V - unknown
+ KATZ  A    2 P 03:067:00000 04:301:00000 V - antenna change
+ KATZ  A    3 P 04:301:00000 00:000:00000 V - 
+ KAYT  A    1 P 00:000:00000 00:280:00000 P - unknown
+ KAYT  A    2 P 00:280:00000 01:262:00000 P - antenna change
+ KAYT  A    3 P 01:262:00000 01:290:00000 P - unknown
+ KAYT  A    4 P 01:290:00000 03:078:00000 P - unknown
+ KAYT  A    5 P 03:078:00000 04:260:00000 P - unknown
+ KAYT  A    6 P 04:260:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ KAYT  A    7 P 04:361:03530 00:000:00000 P -
+ KAYT  A    1 P 00:000:00000 00:000:00000 V -
+ KELS  A    1 P 00:000:00000 98:023:00000 P - antenna change
+ KELS  A    2 P 98:023:00000 00:000:00000 P -
+ KELS  A    1 P 00:000:00000 00:000:00000 V -
+ KEN1  A    1 P 00:000:00000 96:278:00000 P - unknown
+ KEN1  A    2 P 96:278:00000 97:280:00000 P - unknown
+ KEN1  A    3 P 97:280:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ KEN1  A    4 P 02:307:79961 00:000:00000 P - 
+ KEN1  A    1 P 00:000:00000 97:280:00000 V - unknown
+ KEN1  A    2 P 97:280:00000 02:307:79961 V - EQ M7.9 - Central Alaska
+ KEN1  A    3 P 02:307:79961 00:000:00000 V - 
+ KETG  A    1 P 00:000:00000 09:337:43200 P - antenna change
+ KETG  A    2 P 09:337:43200 10:001:00000 P - unknown
+ KETG  A    3 P 10:001:00000 11:034:00000 P - unknown
+ KETG  A    4 P 11:034:00000 00:000:00000 P -
+ KETG  A    1 P 00:000:00000 00:000:00000 V -
+ KGN0  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ KGN0  A    2 P 03:268:71406 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ KGN0  A    3 P 04:249:53839 00:000:00000 P -
+ KGN0  A    1 P 00:000:00000 00:000:00000 V -
+ KGNI  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ KGNI  A    2 P 03:268:71406 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ KGNI  A    3 P 04:249:53839 08:128:60320 P - EQ M6.9 - near the east coast of Honshu, Japan
+ KGNI  A    4 P 08:128:60320 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ KGNI  A    5 P 11:070:20783 12:359:00000 P - unknown mjia
+ KGNI  A    6 P 12:359:00000 00:000:00000 P -
+ KGNI  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ KGNI  A    2 P 11:070:20783 00:000:00000 V -
+ KHAJ  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ KHAJ  A    2 P 03:268:71406 06:319:40458 P - EQ M8.3 - Kuril Islands
+ KHAJ  A    3 P 06:319:40458 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ KHAJ  A    4 P 11:070:20783 00:000:00000 P -
+ KHAJ  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ KHAJ  A    2 P 11:070:20783 00:000:00000 V -
+ KHAR  A    1 P 00:000:00000 06:162:00000 P - unknown
+ KHAR  A    2 P 06:162:00000 08:317:39600 P - antenna change
+ KHAR  A    3 P 08:317:39600 14:220:28800 P - antenna change
+ KHAR  A    4 P 14:220:28800 00:000:00000 P -
+ KHAR  A    1 P 00:000:00000 00:000:00000 V -
+ KINL  A    1 P 00:000:00000 08:339:37800 P - antenna change
+ KINL  A    2 P 08:339:37800 00:000:00000 P -
+ KINL  A    1 P 00:000:00000 00:000:00000 V -
+ KIR0  A    1 P 00:000:00000 00:000:00000 P -
+ KIR0  A    1 P 00:000:00000 00:000:00000 V -
+ KLPD  A    1 P 00:000:00000 00:000:00000 P -
+ KLPD  A    1 P 00:000:00000 00:000:00000 V -
+ KMOR  A    1 P 00:000:00000 00:000:00000 P -
+ KMOR  A    1 P 00:000:00000 00:000:00000 V -
+ KOD1  A    1 P 00:000:00000 99:047:00000 P - unknown
+ KOD1  A    2 P 99:047:00000 02:307:79961 P - EQ M7.9 - Central Alaska
+ KOD1  A    3 P 02:307:79961 00:000:00000 P - 
+ KOD1  A    1 P 00:000:00000 99:047:00000 V - unknown
+ KOD1  A    2 P 99:047:00000 02:307:79961 V - EQ M7.9 - Central Alaska
+ KOD1  A    3 P 02:307:79961 00:000:00000 V - 
+ KOD5  A    1 P 00:000:00000 11:357:00000 P - unknown
+ KOD5  A    2 P 11:357:00000 00:000:00000 P - 
+ KOD5  A    1 P 00:000:00000 00:000:00000 V - 
+ KODK  A    1 P 00:000:00000 00:038:58860 P - receiver change
+ KODK  A    2 P 00:038:58860 00:076:00000 P - unknown
+ KODK  A    3 P 00:076:00000 00:222:00000 P - antenna change
+ KODK  A    4 P 00:222:00000 01:010:57764 P - EQ M7.0 - Kodiak Island region, Alaska
+ KODK  A    5 P 01:010:57764 02:307:79961 P - EQ M7.9 - Central Alaska
+ KODK  A    6 P 02:307:79961 03:012:00000 P - unknown
+ KODK  A    7 P 03:012:00000 00:000:00000 P - 
+ KODK  A    1 P 00:000:00000 02:307:79961 V - EQ M7.9 - Central Alaska
+ KODK  A    2 P 02:307:79961 00:000:00000 V - 
+ KOK1  A    1 P 00:000:00000 96:355:00000 P - receiver change
+ KOK1  A    2 P 96:355:00000 00:000:00000 P -
+ KOK1  A    1 P 00:000:00000 00:000:00000 V -
+ KONE  A    1 P 00:000:00000 10:265:57600 P - antenna change
+ KONE  A    2 P 10:265:57600 00:000:00000 P -
+ KONE  A    1 P 00:000:00000 00:000:00000 V -
+ KOPE  A    1 P 00:000:00000 00:000:00000 P -
+ KOPE  A    1 P 00:000:00000 00:000:00000 V -
+ KOU1  A    1 P 00:000:00000 03:245:00000 P - receiver change
+ KOU1  A    2 P 03:245:00000 00:000:00000 P -
+ KOU1  A    1 P 00:000:00000 00:000:00000 V -
+ KOUC  A    1 P 00:000:00000 02:032:00000 P - non linearity
+ KOUC  A    2 P 02:032:00000 06:136:00000 P - antenna change
+ KOUC  A    3 P 06:136:00000 08:005:00000 P - non linearity
+ KOUC  A    4 P 08:005:00000 09:321:00000 P - antenna change
+ KOUC  A    5 P 09:321:00000 13:034:00000 P - non linearity
+ KOUC  A    6 P 13:034:00000 00:000:00000 P - 
+ KOUC  A    1 P 00:000:00000 02:032:00000 V - non linearity
+ KOUC  A    2 P 02:032:00000 08:005:00000 V - non linearity
+ KOUC  A    3 P 08:005:00000 13:034:00000 V - non linearity
+ KOUC  A    4 P 13:034:00000 00:000:00000 V - 
+ KROT  A    1 P 00:000:00000 00:000:00000 P -
+ KROT  A    1 P 00:000:00000 00:000:00000 V -
+ KRSN  A    1 P 00:000:00000 99:113:18000 P - antenna change
+ KRSN  A    2 P 99:113:18000 00:014:00000 P - antenna change
+ KRSN  A    3 P 00:014:00000 01:026:00000 P - antenna change
+ KRSN  A    4 P 01:026:00000 00:000:00000 P -
+ KRSN  A    1 P 00:000:00000 00:000:00000 V -
+ KRTV  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ KRTV  A    2 P 11:070:20783 00:000:00000 P -
+ KRTV  A    1 P 00:000:00000 00:000:00000 V -
+ KSMV  A    1 P 00:000:00000 08:128:57723 P - EQ M6.2 - near the east coast of Honshu, Japan
+ KSMV  A    2 P 08:128:57723 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ KSMV  A    3 P 11:070:20783 13:298:61820 P - EQ M7.1 - Off the east coast of Honshu, Japan
+ KSMV  A    4 P 13:298:61820 00:000:00000 P -
+ KSMV  A    1 P 00:000:00000 00:000:00000 V -
+ KSNB  A    1 P 00:000:00000 09:349:00000 P - non linearity
+ KSNB  A    2 P 09:349:00000 00:000:00000 P - 
+ KSNB  A    1 P 00:000:00000 09:349:00000 V - non linearity
+ KSNB  A    2 P 09:349:00000 00:000:00000 V -
+ KSTU  A    1 P 00:000:00000 99:113:18000 P - antenna change
+ KSTU  A    2 P 99:113:18000 00:014:00000 P - antenna change
+ KSTU  A    3 P 00:014:00000 01:026:00000 P - antenna change
+ KSTU  A    4 P 01:026:00000 00:000:00000 P -
+ KSTU  A    1 P 00:000:00000 00:000:00000 V -
+ KTVL  A    1 P 00:000:00000 00:000:00000 P -
+ KTVL  A    1 P 00:000:00000 00:000:00000 V -
+ KUAL  A    1 P 00:000:00000 07:255:40227 P - EQ M8.5 - southern Sumatra, Indonesia
+ KUAL  A    2 P 07:255:40227 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ KUAL  A    3 P 12:102:31117 00:000:00000 P -
+ KUAL  A    1 P 00:000:00000 00:000:00000 V -
+ KULL  A    1 P 00:000:00000 00:000:00000 P -
+ KULL  A    1 P 00:000:00000 00:000:00000 V -
+ KULU  A    1 P 00:000:00000 99:129:00000 P - antenna change
+ KULU  A    2 P 99:129:00000 03:076:00000 P - non linearity
+ KULU  A    3 P 03:076:00000 00:000:00000 P - 
+ KULU  A    1 P 00:000:00000 03:076:00000 V - non linearity
+ KULU  A    2 P 03:076:00000 00:000:00000 V - 
+ KUMT  A    1 P 00:000:00000 97:289:00000 P - unknown
+ KUMT  A    2 P 97:289:00000 00:313:00000 P - receiver change
+ KUMT  A    3 P 00:313:00000 00:000:00000 P -
+ KUMT  A    1 P 00:000:00000 97:289:00000 V - unknown
+ KUMT  A    2 P 97:289:00000 00:000:00000 V -
+ KUNM  A    1 P 00:000:00000 03:086:00000 P - non linearity
+ KUNM  A    2 P 03:086:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ KUNM  A    3 P 04:361:03530 09:019:00000 P - non linearity
+ KUNM  A    4 P 09:019:00000 10:360:00000 P - non linearity
+ KUNM  A    5 P 10:360:00000 00:000:00000 P - 
+ KUNM  A    1 P 00:000:00000 03:086:00000 V - non linearity
+ KUNM  A    2 P 03:086:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ KUNM  A    3 P 04:361:03530 09:019:00000 V - non linearity
+ KUNM  A    4 P 09:019:00000 10:360:00000 V - non linearity
+ KUNM  A    5 P 10:360:00000 00:000:00000 V - 
+ KUUJ  A    1 P 00:000:00000 05:215:52560 P - antenna change
+ KUUJ  A    2 P 05:215:52560 10:211:00000 P - antenna change
+ KUUJ  A    3 P 10:211:00000 00:000:00000 P -
+ KUUJ  A    1 P 00:000:00000 00:000:00000 V -
+ KUWT  A    1 P 00:000:00000 11:168:00000 P - unknown
+ KUWT  A    2 P 11:168:00000 00:000:00000 P -
+ KUWT  A    1 P 00:000:00000 00:000:00000 V -
+ KWST  A    1 P 00:000:00000 00:000:00000 P -
+ KWST  A    1 P 00:000:00000 00:000:00000 V -
+ KYW1  A    1 P 00:000:00000 05:296:00000 P - unknown
+ KYW1  A    2 P 05:296:00000 00:000:00000 P -
+ KYW1  A    1 P 00:000:00000 00:000:00000 V -
+ KYW5  A    1 P 00:000:00000 00:000:00000 P -
+ KYW5  A    1 P 00:000:00000 00:000:00000 V -
+ LAE1  A    1 P 00:000:00000 99:096:30134 P - EQ M6.4 - eastern New Guinea region, Papua New Guinea
+ LAE1  A    2 P 99:096:30134 00:321:17697 P - EQ M8.0 - New Ireland region, Papua New Guinea
+ LAE1  A    3 P 00:321:17697 07:326:31708 P - EQ M6.8 - eastern New Guinea region, Papua New Guinea
+ LAE1  A    4 P 07:326:31708 00:000:00000 P -
+ LAE1  A    1 P 00:000:00000 00:000:00000 V -
+ LAGO  A    1 P 00:000:00000 10:064:54000 P - antenna change
+ LAGO  A    2 P 10:064:54000 00:000:00000 P -
+ LAGO  A    1 P 00:000:00000 00:000:00000 V -
+ LAM0  A    1 P 00:000:00000 07:333:68420 P - EQ M7.4 - Martinique region, Windward Islands
+ LAM0  A    2 P 07:333:68420 10:099:00000 P - unknown
+ LAM0  A    3 P 10:099:00000 00:000:00000 P -
+ LAM0  A    1 P 00:000:00000 00:000:00000 V -
+ LAMA  A    1 P 00:000:00000 00:280:00000 P - antenna change
+ LAMA  A    2 P 00:280:00000 07:321:68400 P - antenna change
+ LAMA  A    3 P 07:321:68400 00:000:00000 P -
+ LAMA  A    1 P 00:000:00000 00:000:00000 V -
+ LAMP  A    1 P 00:000:00000 10:048:00000 P - antenna change
+ LAMP  A    2 P 10:048:00000 12:242:00000 P - non linearity
+ LAMP  A    3 P 12:242:00000 14:101:54000 P - antenna change
+ LAMP  A    4 P 14:101:54000 14:308:50400 P - receiver change
+ LAMP  A    5 P 14:308:50400 00:000:00000 P - 
+ LAMP  A    1 P 00:000:00000 10:048:00000 V - antenna change
+ LAMP  A    2 P 10:048:00000 12:242:00000 V - non linearity
+ LAMP  A    3 P 12:242:00000 00:000:00000 V - 
+ LARR  A    1 P 00:000:00000 11:062:00000 P - non linearity
+ LARR  A    2 P 11:062:00000 00:000:00000 P - 
+ LARR  A    1 P 00:000:00000 11:062:00000 V - non linearity
+ LARR  A    2 P 11:062:00000 00:000:00000 V - 
+ LCKI  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ LCKI  A    2 P 12:102:31117 00:000:00000 P -
+ LCKI  A    1 P 00:000:00000 00:000:00000 V -
+ LDHI  A    1 P 00:000:00000 00:000:00000 P -
+ LDHI  A    1 P 00:000:00000 00:000:00000 V -
+ LEEP  A    1 P 00:000:00000 00:295:00000 P - antenna change
+ LEEP  A    2 P 00:295:00000 00:000:00000 P -
+ LEEP  A    1 P 00:000:00000 00:000:00000 V -
+ LEPA  A    1 P 00:000:00000 07:180:00000 P - unknown
+ LEPA  A    2 P 07:180:00000 09:008:69696 P - EQ M6.1 - Costa Rica
+ LEPA  A    3 P 09:008:69696 12:249:52928 P - EQ M7.6 - Costa Rica
+ LEPA  A    4 P 12:249:52928 00:000:00000 P - 
+ LEPA  A    1 P 00:000:00000 00:000:00000 V - 
+ LHAV  A    1 P 00:000:00000 00:000:00000 P -
+ LHAV  A    1 P 00:000:00000 00:000:00000 V -
+ LHCL  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ LHCL  A    2 P 10:058:23652 12:117:00000 P - antenna change
+ LHCL  A    3 P 12:117:00000 00:000:00000 P -
+ LHCL  A    1 P 00:000:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ LHCL  A    2 P 10:058:23652 00:000:00000 V -
+ LHUE  A    1 P 00:000:00000 00:000:00000 P -
+ LHUE  A    1 P 00:000:00000 00:000:00000 V -
+ LIVE  A    1 P 00:000:00000 02:356:00000 P - unknown
+ LIVE  A    2 P 02:356:00000 03:349:00000 P - unknown
+ LIVE  A    3 P 03:349:00000 04:285:00000 P - unknown
+ LIVE  A    4 P 04:285:00000 05:074:32400 P - antenna change
+ LIVE  A    5 P 05:074:32400 00:000:00000 P -
+ LIVE  A    1 P 00:000:00000 00:000:00000 V -
+ LKHU  A    1 P 00:000:00000 95:316:00000 P - unknown
+ LKHU  A    2 P 95:316:00000 98:168:00000 P - antenna change
+ LKHU  A    3 P 98:168:00000 02:190:00000 P - antenna change
+ LKHU  A    4 P 02:190:00000 03:212:00000 P - unknown
+ LKHU  A    5 P 03:212:00000 07:026:00000 P - antenna change
+ LKHU  A    6 P 07:026:00000 08:116:00000 P - unknown
+ LKHU  A    7 P 08:116:00000 11:168:00000 P - unknown
+ LKHU  A    8 P 11:168:00000 13:283:00000 P - antenna change
+ LKHU  A    9 P 13:283:00000 15:012:00000 P - unknown
+ LKHU  A   10 P 15:012:00000 00:000:00000 P -
+ LKHU  A    1 P 00:000:00000 00:000:00000 V -
+ LKTH  A    1 P 00:000:00000 00:000:00000 P -
+ LKTH  A    1 P 00:000:00000 00:000:00000 V -
+ LLIV  A    1 P 00:000:00000 99:313:46800 P - receiver change
+ LLIV  A    2 P 99:313:46800 00:000:00000 P -
+ LLIV  A    1 P 00:000:00000 00:000:00000 V -
+ LMNO  A    1 P 00:000:00000 00:055:77400 P - antenna change
+ LMNO  A    2 P 00:055:77400 01:152:61200 P - antenna change
+ LMNO  A    3 P 01:152:61200 00:000:00000 P -
+ LMNO  A    1 P 00:000:00000 00:000:00000 V -
+ LORD  A    1 P 00:000:00000 14:185:00000 P - receiver change
+ LORD  A    2 P 14:185:00000 00:000:00000 P -
+ LORD  A    1 P 00:000:00000 00:000:00000 V -
+ LOWE  A    1 P 00:000:00000 00:000:00000 P -
+ LOWE  A    1 P 00:000:00000 00:000:00000 V -
+ LPAZ  A    1 P 00:000:00000 10:294:64393 P - EQ M6.7 - Gulf of California
+ LPAZ  A    2 P 10:294:64393 00:000:00000 P - 
+ LPAZ  A    1 P 00:000:00000 10:294:64393 V - EQ M6.7 - Gulf of California
+ LPAZ  A    2 P 10:294:64393 00:000:00000 V - 
+ LPIL  A    1 P 00:000:00000 06:091:00000 P - antenna change
+ LPIL  A    2 P 06:091:00000 06:136:00000 P - unknown
+ LPIL  A    3 P 06:136:00000 07:084:02402 P - EQ M7.1 - Vanuatu
+ LPIL  A    4 P 07:084:02402 08:100:45973 P - EQ M7.3 - Loyalty Islands, New Caledonia
+ LPIL  A    5 P 08:100:45973 10:359:47797 P - EQ M7.3 - Vanuatu region
+ LPIL  A    6 P 10:359:47797 11:013:58602 P - EQ M7.0 - Loyalty Islands, New Caledonia
+ LPIL  A    7 P 11:013:58602 11:130:32109 P - EQ M6.8 - Loyalty Islands, New Caledonia
+ LPIL  A    8 P 11:130:32109 14:050:00000 P - unknown
+ LPIL  A    9 P 14:050:00000 00:000:00000 P -
+ LPIL  A    1 P 00:000:00000 00:000:00000 V -
+ LPPZ  A    1 P 00:000:00000 10:265:43200 P - antenna change
+ LPPZ  A    2 P 10:265:43200 00:000:00000 P -
+ LPPZ  A    1 P 00:000:00000 00:000:00000 V -
+ LWTG  A    1 P 00:000:00000 11:188:00000 P - antenna change
+ LWTG  A    2 P 11:188:00000 13:192:43200 P - antenna change
+ LWTG  A    3 P 13:192:43200 00:000:00000 P -
+ LWTG  A    1 P 00:000:00000 00:000:00000 V -
+ LYNS  A    1 P 00:000:00000 00:000:00000 P -
+ LYNS  A    1 P 00:000:00000 00:000:00000 V -
+ LYTT  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ LYTT  A    2 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ LYTT  A    3 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ LYTT  A    4 P 10:246:59748 11:052:85903 P - EQ M6.1 - South Island of New Zealand
+ LYTT  A    5 P 11:052:85903 11:164:08449 P - EQ M5.9 - South Island of New Zealand
+ LYTT  A    6 P 11:164:08449 11:357:08282 P - EQ M5.9 - South Island of New Zealand
+ LYTT  A    7 P 11:357:08282 16:049:00000 P - unknown mjia
+ LYTT  A    8 P 16:049:00000 16:318:00000 P -
+ LYTT  A    9 P 16:318:00000 00:000:00000 P -
+ LYTT  A    1 P 00:000:00000 00:000:00000 V -
+ MAD2  A    1 P 00:000:00000 97:313:00000 P - unknown
+ MAD2  A    2 P 97:313:00000 98:153:00000 P - unknown
+ MAD2  A    3 P 98:153:00000 98:217:00000 P - unknown
+ MAD2  A    4 P 98:217:00000 98:354:00000 P - unknown
+ MAD2  A    5 P 98:354:00000 99:346:00000 P - unknown
+ MAD2  A    6 P 99:346:00000 03:302:00000 P - antenna change
+ MAD2  A    7 P 03:302:00000 03:315:48600 P - antenna change
+ MAD2  A    8 P 03:315:48600 04:334:82200 P - receiver change
+ MAD2  A    9 P 04:334:82200 11:018:00000 P - unknown
+ MAD2  A   10 P 11:018:00000 00:000:00000 P -
+ MAD2  A    1 P 00:000:00000 00:000:00000 V -
+ MADR  A    1 P 00:000:00000 96:277:00000 P - receiver change
+ MADR  A    2 P 96:277:00000 97:010:00000 P - unknown
+ MADR  A    3 P 97:010:00000 97:313:00000 P - unknown
+ MADR  A    4 P 97:313:00000 98:153:00000 P - unknown
+ MADR  A    5 P 98:153:00000 98:217:00000 P - unknown
+ MADR  A    6 P 98:217:00000 98:354:00000 P - unknown
+ MADR  A    7 P 98:354:00000 99:362:00000 P - unknown
+ MADR  A    8 P 99:362:00000 03:302:00000 P - antenna change
+ MADR  A    9 P 03:302:00000 03:315:48600 P - antenna change
+ MADR  A   10 P 03:315:48600 11:018:00000 P - unknown
+ MADR  A   11 P 11:018:00000 14:015:69300 P - receiver change
+ MADR  A   12 P 14:015:69300 00:000:00000 P -
+ MADR  A    1 P 00:000:00000 00:000:00000 V -
+ MAEW  A    1 P 00:000:00000 08:312:26376 P - EQ M6.4 - Vanuatu
+ MAEW  A    2 P 08:312:26376 09:280:79395 P - EQ M7.7 - Vanuatu
+ MAEW  A    3 P 09:280:79395 00:000:00000 P -
+ MAEW  A    1 P 00:000:00000 00:000:00000 V -
+ MAG0  A    1 P 00:000:00000 00:307:00000 P - non linearity
+ MAG0  A    2 P 00:307:00000 02:255:00000 P - unknown
+ MAG0  A    3 P 02:255:00000 11:187:00000 P - receiver change
+ MAG0  A    4 P 11:187:00000 12:180:00000 P - non linearity
+ MAG0  A    5 P 12:180:00000 13:144:20689 P - EQ M8.3 - Sea of Okhotsk
+ MAG0  A    6 P 13:144:20689 00:000:00000 P - 
+ MAG0  A    1 P 00:000:00000 00:307:00000 V - non linearity
+ MAG0  A    2 P 00:307:00000 12:180:00000 V - non linearity
+ MAG0  A    3 P 12:180:00000 00:000:00000 V -
+ MAJU  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ MAJU  A    2 P 11:070:20783 12:085:10680 P - antenna change
+ MAJU  A    3 P 12:085:10680 13:288:00000 P - antenna change
+ MAJU  A    4 P 13:288:00000 00:000:00000 P -
+ MAJU  A    1 P 00:000:00000 00:000:00000 V -
+ MALA  A    1 P 00:000:00000 08:225:00000 P - antenna change
+ MALA  A    2 P 08:225:00000 00:000:00000 P -
+ MALA  A    1 P 00:000:00000 00:000:00000 V -
+ MALD  A    1 P 00:000:00000 00:150:00000 P - unknown
+ MALD  A    2 P 00:150:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ MALD  A    3 P 04:361:03530 00:000:00000 P -
+ MALD  A    1 P 00:000:00000 00:000:00000 V -
+ MALL  A    1 P 00:000:00000 03:141:67460 P - EQ M6.8 - northern Algeria
+ MALL  A    2 P 03:141:67460 03:229:00000 P - unknown
+ MALL  A    3 P 03:229:00000 08:304:00000 P - antenna change
+ MALL  A    4 P 08:304:00000 00:000:00000 P -
+ MALL  A    1 P 00:000:00000 03:229:00000 V - unknown
+ MALL  A    2 P 03:229:00000 00:000:00000 V -
+ MANA  B    1 P 00:000:00000 04:283:77214 P - EQ M7.0 - near the coast of Nicaragua
+ MANA  B    2 P 04:283:77214 05:183:08204 P - EQ M6.6 - near the coast of Nicaragua
+ MANA  B    3 P 05:183:08204 12:249:52928 P - EQ M7.6 - Costa Rica
+ MANA  B    4 P 12:249:52928 14:100:84466 P - EQ M6.1 - 16km SW of Valle San Francisco, Nicaragua
+ MANA  B    5 P 14:100:84466 00:000:00000 P -
+ MANA  B    1 P 00:000:00000 04:283:77214 V - EQ M7.0 - near the coast of Nicaragua
+ MANA  B    2 P 04:283:77214 00:000:00000 V -
+ MAPA  A    1 P 00:000:00000 11:256:00000 P - unknown
+ MAPA  A    2 P 11:256:00000 12:005:00000 P - unknown
+ MAPA  A    3 P 12:005:00000 12:015:00000 P - unknown
+ MAPA  A    4 P 12:015:00000 00:000:00000 P -
+ MAPA  A    1 P 00:000:00000 00:000:00000 V -
+ MARA  B    1 P 00:000:00000 08:197:00000 P - antenna change
+ MARA  B    2 P 08:197:00000 09:071:00000 P - receiver change
+ MARA  B    3 P 09:071:00000 09:209:00000 P - receiver change
+ MARA  B    4 P 09:209:00000 00:000:00000 P -
+ MARA  B    1 P 00:000:00000 00:000:00000 V -
+ MARG  A    1 P 00:000:00000 09:190:00000 P - unknown
+ MARG  A    2 P 09:190:00000 00:000:00000 P -
+ MARG  A    1 P 00:000:00000 00:000:00000 V -
+ MARN  A    1 P 00:000:00000 11:128:00000 P - unknown
+ MARN  A    2 P 11:128:00000 12:261:00000 P - unknown
+ MARN  A    3 P 12:261:00000 14:251:00000 P - unknown
+ MARN  A    4 P 14:251:00000 00:000:00000 P - 
+ MARN  A    1 P 00:000:00000 11:128:00000 V - unknown
+ MARN  A    2 P 11:128:00000 12:261:00000 V - unknown
+ MARN  A    3 P 12:261:00000 00:000:00000 V -
+ MARS  A    1 P 00:000:00000 03:087:00000 P - antenna change
+ MARS  A    2 P 03:087:00000 04:210:00000 P - antenna change
+ MARS  A    3 P 04:210:00000 09:077:00000 P - antenna change
+ MARS  A    4 P 09:077:00000 12:270:46800 P - antenna change
+ MARS  A    5 P 12:270:46800 00:000:00000 P -
+ MARS  A    1 P 00:000:00000 00:000:00000 V -
+ MATH  A    1 P 00:000:00000 94:306:00000 P - receiver change
+ MATH  A    2 P 94:306:00000 99:289:35204 P - EQ M7.1 - Southern California
+ MATH  A    3 P 99:289:35204 00:000:00000 P -
+ MATH  A    1 P 00:000:00000 00:000:00000 V -
+ MAYZ  A    1 P 00:000:00000 00:000:00000 P -
+ MAYZ  A    1 P 00:000:00000 00:000:00000 V -
+ MCD1  A    1 P 00:000:00000 00:000:00000 P -
+ MCD1  A    1 P 00:000:00000 00:000:00000 V -
+ MCD5  A    1 P 00:000:00000 00:000:00000 P -
+ MCD5  A    1 P 00:000:00000 00:000:00000 V -
+ MDSI  A    1 P 00:000:00000 00:000:00000 P -
+ MDSI  A    1 P 00:000:00000 00:000:00000 V -
+ MERI  A    1 P 00:000:00000 09:148:30285 P - EQ M7.3 - offshore Honduras
+ MERI  A    2 P 09:148:30285 00:000:00000 P -
+ MERI  A    1 P 00:000:00000 00:000:00000 V -
+ MERS  A    1 P 00:000:00000 00:000:00000 P -
+ MERS  A    1 P 00:000:00000 00:000:00000 V -
+ METZ  A    1 P 00:000:00000 00:000:00000 P -
+ METZ  A    1 P 00:000:00000 00:000:00000 V -
+ MFKG  A    1 P 00:000:00000 14:073:00000 P - unknown
+ MFKG  A    2 P 14:073:00000 00:000:00000 P -
+ MFKG  A    1 P 00:000:00000 00:000:00000 V -
+ MGUE  A    1 P 00:000:00000 00:000:00000 P -
+ MGUE  A    1 P 00:000:00000 00:000:00000 V -
+ MHCB  A    1 P 00:000:00000 14:022:00000 P - unknown
+ MHCB  A    2 P 14:022:00000 00:000:00000 P -
+ MHCB  A    1 P 00:000:00000 00:000:00000 V -
+ MIA1  A    1 P 00:000:00000 00:000:00000 P -
+ MIA1  A    1 P 00:000:00000 00:000:00000 V -
+ MIA3  A    1 P 00:000:00000 05:307:00000 P - unknown
+ MIA3  A    2 P 05:307:00000 00:000:00000 P -
+ MIA3  A    1 P 00:000:00000 00:000:00000 V -
+ MIG1  A    1 P 00:000:00000 00:000:00000 P -
+ MIG1  A    1 P 00:000:00000 00:000:00000 V -
+ MIKL  A    1 P 00:000:00000 00:000:00000 P -
+ MIKL  A    1 P 00:000:00000 00:000:00000 V -
+ MIL1  A    1 P 00:000:00000 00:000:00000 P -
+ MIL1  A    1 P 00:000:00000 00:000:00000 V -
+ MIZU  A    1 P 00:000:00000 02:307:13062 P - EQ M6.4 - near the east coast of Honshu, Japan
+ MIZU  A    2 P 02:307:13062 03:146:33873 P - EQ M7.0 - near the east coast of Honshu, Japan
+ MIZU  A    3 P 03:146:33873 03:311:00000 P - antenna change
+ MIZU  A    4 P 03:311:00000 05:194:00000 P - antenna change
+ MIZU  A    5 P 05:194:00000 05:228:09988 P - EQ M7.2 - near the east coast of Honshu, Japan
+ MIZU  A    6 P 05:228:09988 08:165:85425 P - EQ M6.9 - eastern Honshu, Japan
+ MIZU  A    7 P 08:165:85425 08:205:55580 P - EQ M6.8 - eastern Honshu, Japan
+ MIZU  A    8 P 08:205:55580 11:068:09920 P - EQ M7.3 - near the east coast of Honshu, Japan
+ MIZU  A    9 P 11:068:09920 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ MIZU  A   10 P 11:070:20783 12:169:73941 P - EQ M6.3 - near the east coast of Honshu, Japan
+ MIZU  A   11 P 12:169:73941 14:324:34200 P - antenna change
+ MIZU  A   12 P 14:324:34200 00:000:00000 P -
+ MIZU  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ MIZU  A    2 P 11:070:20783 00:000:00000 V -
+ MLF1  A    1 P 00:000:00000 97:246:00000 P - antenna change
+ MLF1  A    2 P 97:246:00000 99:173:00000 P - receiver change
+ MLF1  A    3 P 99:173:00000 00:000:00000 P -
+ MLF1  A    1 P 00:000:00000 00:000:00000 V -
+ MLF1  A    2 P 97:246:00000 99:173:00000 P - receiver change
+ MNP1  A    1 P 00:000:00000 00:000:00000 P -
+ MNP1  A    1 P 00:000:00000 00:000:00000 V -
+ MOB1  A    1 P 00:000:00000 00:000:00000 P -
+ MOB1  A    1 P 00:000:00000 00:000:00000 V -
+ MOBJ  A    1 P 00:000:00000 07:144:36360 P - antenna change
+ MOBJ  A    2 P 07:144:36360 08:255:00000 P - unknown
+ MOBJ  A    3 P 08:255:00000 00:000:00000 P -
+ MOBJ  A    1 P 00:000:00000 00:000:00000 V -
+ MOBN  A    1 P 00:000:00000 00:000:00000 P -
+ MOBN  A    1 P 00:000:00000 00:000:00000 V -
+ MORP  A    1 P 00:000:00000 97:030:00000 P - unknown
+ MORP  A    2 P 97:030:00000 05:165:57600 P - antenna change
+ MORP  A    3 P 05:165:57600 09:207:00000 P - antenna change
+ MORP  A    4 P 09:207:00000 09:229:49200 P - antenna change
+ MORP  A    5 P 09:229:49200 11:048:00000 P - unknown
+ MORP  A    6 P 11:048:00000 00:000:00000 P -
+ MORP  A    1 P 00:000:00000 00:000:00000 V -
+ MPL2  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ MPL2  A    2 P 10:058:23652 00:000:00000 P -
+ MPL2  A    1 P 00:000:00000 00:000:00000 V -
+ MPLA  A    1 P 00:000:00000 00:000:00000 P -
+ MPLA  A    1 P 00:000:00000 00:000:00000 V -
+ MPR1  A    1 P 00:000:00000 00:000:00000 P -
+ MPR1  A    1 P 00:000:00000 00:000:00000 V -
+ MSD1  A    1 P 00:000:00000 00:000:00000 P -
+ MSD1  A    1 P 00:000:00000 00:000:00000 V -
+ MTJO  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ MTJO  A    2 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ MTJO  A    3 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ MTJO  A    4 P 10:246:59748 11:038:39600 P - antenna change
+ MTJO  A    5 P 11:038:39600 16:318:00000 P -
+ MTJO  A    6 P 16:318:00000 00:000:00000 P -
+ MTJO  A    1 P 00:000:00000 00:000:00000 V -
+ MTY2  A    1 P 00:000:00000 00:000:00000 P -
+ MTY2  A    1 P 00:000:00000 00:000:00000 V -
+ NAGA  A    1 P 00:000:00000 96:231:00000 P - receiver change
+ NAGA  A    2 P 96:231:00000 99:303:00000 P - antenna change
+ NAGA  A    3 P 99:303:00000 00:000:00000 P -
+ NAGA  A    1 P 00:000:00000 00:000:00000 V -
+ NAPL  A    1 P 00:000:00000 00:000:00000 P -
+ NAPL  A    1 P 00:000:00000 00:000:00000 V -
+ NAS0  A    1 P 00:000:00000 00:000:00000 P -
+ NAS0  A    1 P 00:000:00000 00:000:00000 V -
+ NAUS  A    1 P 00:000:00000 13:099:52980 P - antenna change
+ NAUS  A    2 P 13:099:52980 14:240:45600 P - antenna change
+ NAUS  A    3 P 14:240:45600 00:000:00000 P -
+ NAUS  A    1 P 00:000:00000 00:000:00000 V -
+ NCDU  A    1 P 00:000:00000 09:013:00000 P - antenna change
+ NCDU  A    2 P 09:013:00000 00:000:00000 P -
+ NCDU  A    1 P 00:000:00000 00:000:00000 V -
+ NDBC  A    1 P 00:000:00000 99:173:82800 P - antenna change
+ NDBC  A    2 P 99:173:82800 00:000:00000 P -
+ NDBC  A    1 P 00:000:00000 00:000:00000 V -
+ NEAH  A    1 P 00:000:00000 97:033:00000 P - antenna change
+ NEAH  A    2 P 97:033:00000 12:276:00000 P - unknown
+ NEAH  A    3 P 12:276:00000 00:000:00000 P -
+ NEAH  A    1 P 00:000:00000 00:000:00000 V -
+ NEIA  A    1 P 00:000:00000 09:254:50400 P - antenna change
+ NEIA  A    2 P 09:254:50400 09:321:00000 P - antenna change
+ NEIA  A    3 P 09:321:00000 12:242:50400 P - antenna change
+ NEIA  A    4 P 12:242:50400 00:000:00000 P -
+ NEIA  A    1 P 00:000:00000 00:000:00000 V -
+ NEWL  A    1 P 00:000:00000 08:138:00000 P - antenna change
+ NEWL  A    2 P 08:138:00000 08:150:00000 P - antenna change
+ NEWL  A    3 P 08:150:00000 13:141:43200 P - antenna change
+ NEWL  A    4 P 13:141:43200 00:000:00000 P -
+ NEWL  A    1 P 00:000:00000 00:000:00000 V -
+ NICA  A    1 P 00:000:00000 13:004:50400 P - antenna change
+ NICA  A    2 P 13:004:50400 00:000:00000 P -
+ NICA  A    1 P 00:000:00000 00:000:00000 V -
+ NJCM  A    1 P 00:000:00000 13:092:64800 P - antenna change
+ NJCM  A    2 P 13:092:64800 00:000:00000 P -
+ NJCM  A    1 P 00:000:00000 00:000:00000 V -
+ NJGT  A    1 P 00:000:00000 13:290:00000 P - unknown
+ NJGT  A    2 P 13:290:00000 00:000:00000 P -
+ NJGT  A    1 P 00:000:00000 00:000:00000 V -
+ NJI2  A    1 P 00:000:00000 13:030:00000 P - antenna change
+ NJI2  A    2 P 13:030:00000 00:000:00000 P -
+ NJI2  A    1 P 00:000:00000 00:000:00000 V -
+ NMEA  A    1 P 00:000:00000 00:000:00000 P -
+ NMEA  A    1 P 00:000:00000 00:000:00000 V -
+ NNVN  A    1 P 00:000:00000 00:000:00000 P -
+ NNVN  A    1 P 00:000:00000 00:000:00000 V -
+ NORF  A    1 P 00:000:00000 00:000:00000 P -
+ NORF  A    1 P 00:000:00000 00:000:00000 V -
+ NOTO  A    1 P 00:000:00000 98:211:00000 P - antenna change
+ NOTO  A    2 P 98:211:00000 00:000:00000 P -
+ NOTO  A    1 P 00:000:00000 00:000:00000 V -
+ NPLD  A    1 P 00:000:00000 04:254:00000 P - unknown
+ NPLD  A    2 P 04:254:00000 00:000:00000 P -
+ NPLD  A    1 P 00:000:00000 00:000:00000 V -
+ NPLY  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ NPLY  A    2 P 04:358:53944 16:318:00000 P -
+ NPLY  A    3 P 16:318:00000 00:000:00000 P -
+ NPLY  A    1 P 00:000:00000 00:000:00000 V -
+ NPRI  A    1 P 00:000:00000 14:191:00000 P - antenna change
+ NPRI  A    2 P 14:191:00000 00:000:00000 P -
+ NPRI  A    1 P 00:000:00000 00:000:00000 V -
+ NRIF  A    1 P 00:000:00000 00:000:00000 P -
+ NRIF  A    1 P 00:000:00000 00:000:00000 V -
+ NRL1  A    1 P 00:000:00000 00:000:00000 P -
+ NRL1  A    1 P 00:000:00000 00:000:00000 V -
+ NSLG  A    1 P 00:000:00000 00:000:00000 P -
+ NSLG  A    1 P 00:000:00000 00:000:00000 V -
+ NSSP  A    1 P 00:000:00000 03:038:00000 P - antenna change
+ NSSP  A    2 P 03:038:00000 00:000:00000 P -
+ NSSP  A    1 P 00:000:00000 00:000:00000 V -
+ NSSS  A    1 P 00:000:00000 11:101:65220 P - antenna change
+ NSSS  A    2 P 11:101:65220 00:000:00000 P -
+ NSSS  A    1 P 00:000:00000 00:000:00000 V -
+ NSTG  A    1 P 00:000:00000 99:337:00000 P - antenna change
+ NSTG  A    2 P 99:337:00000 00:043:00000 P - antenna change
+ NSTG  A    3 P 00:043:00000 01:135:00000 P - antenna change
+ NSTG  A    4 P 01:135:00000 01:163:46800 P - antenna change
+ NSTG  A    5 P 01:163:46800 02:072:00000 P - antenna change
+ NSTG  A    6 P 02:072:00000 02:095:00000 P - antenna change
+ NSTG  A    7 P 02:095:00000 00:000:00000 P -
+ NSTG  A    1 P 00:000:00000 00:000:00000 V -
+ NTUS  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ NTUS  A    2 P 04:361:03530 05:087:58177 P - EQ M8.6 - northern Sumatra, Indonesia
+ NTUS  A    3 P 05:087:58177 07:136:00000 P - antenna change
+ NTUS  A    4 P 07:136:00000 07:255:40227 P - EQ M8.5 - southern Sumatra, Indonesia
+ NTUS  A    5 P 07:255:40227 10:298:52943 P - EQ M7.8 - Kepulauan Mentawai region, Indonesia
+ NTUS  A    6 P 10:298:52943 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ NTUS  A    7 P 12:102:31117 00:000:00000 P -
+ NTUS  A    1 P 00:000:00000 00:000:00000 V -
+ NVSK  A    1 P 00:000:00000 00:000:00000 P -
+ NVSK  A    1 P 00:000:00000 00:000:00000 V -
+ NYAC  A    1 P 00:000:00000 00:000:00000 P -
+ NYAC  A    1 P 00:000:00000 00:000:00000 V -
+ NYBP  A    1 P 00:000:00000 00:000:00000 P -
+ NYBP  A    1 P 00:000:00000 00:000:00000 V -
+ NYQN  A    1 P 00:000:00000 08:163:00000 P - unknown
+ NYQN  A    2 P 08:163:00000 00:000:00000 P -
+ NYQN  A    1 P 00:000:00000 00:000:00000 V -
+ OAX2  A    1 P 00:000:00000 07:326:00000 P - unknown
+ OAX2  A    2 P 07:326:00000 08:034:00000 P - unknown
+ OAX2  A    3 P 08:034:00000 12:080:64968 P - EQ M7.4 - Oaxaca, Mexico
+ OAX2  A    4 P 12:080:64968 00:000:00000 P -
+ OAX2  A    1 P 00:000:00000 00:000:00000 V -
+ OBE2  A    1 P 00:000:00000 01:309:00000 P - unknown
+ OBE2  A    2 P 01:309:00000 00:000:00000 P -
+ OBE2  A    1 P 00:000:00000 00:000:00000 V -
+ OBE3  A    1 P 00:000:00000 12:012:39600 P - antenna change
+ OBE3  A    2 P 12:012:39600 12:046:00000 P - unknown
+ OBE3  A    3 P 12:046:00000 00:000:00000 P -
+ OBE3  A    1 P 00:000:00000 00:000:00000 V -
+ OBER  A    1 P 00:000:00000 01:157:00000 P - unknown
+ OBER  A    2 P 01:157:00000 01:210:00000 P - unknown
+ OBER  A    3 P 01:210:00000 00:000:00000 P -
+ OBER  A    1 P 00:000:00000 00:000:00000 V -
+ ODS5  A    1 P 00:000:00000 00:000:00000 P -
+ ODS5  A    1 P 00:000:00000 00:000:00000 V -
+ OGHS  A    1 P 00:000:00000 00:000:00000 P -
+ OGHS  A    1 P 00:000:00000 00:000:00000 V -
+ OKOM  A    1 P 00:000:00000 00:000:00000 P -
+ OKOM  A    1 P 00:000:00000 00:000:00000 V -
+ OOST  A    1 P 00:000:00000 00:000:00000 P -
+ OOST  A    1 P 00:000:00000 00:000:00000 V -
+ OPMT  A    1 P 00:000:00000 00:000:00000 P -
+ OPMT  A    1 P 00:000:00000 00:000:00000 V -
+ ORID  A    1 P 00:000:00000 02:304:43200 P - antenna change
+ ORID  A    2 P 02:304:43200 02:347:43200 P - antenna change
+ ORID  A    3 P 02:347:43200 08:311:25200 P - antenna change
+ ORID  A    4 P 08:311:25200 00:000:00000 P -
+ ORID  A    1 P 00:000:00000 00:000:00000 V -
+ OS0G  A    1 P 00:000:00000 99:033:00000 P - antenna change
+ OS0G  A    2 P 99:033:00000 00:000:00000 P -
+ OS0G  A    1 P 00:000:00000 00:000:00000 V -
+ OSLS  A    1 P 00:000:00000 07:113:52500 P - antenna change
+ OSLS  A    2 P 07:113:52500 00:000:00000 P -
+ OSLS  A    1 P 00:000:00000 00:000:00000 V -
+ OSN2  A    1 P 00:000:00000 09:209:00000 P - antenna change
+ OSN2  A    2 P 09:209:00000 00:000:00000 P -
+ OSN2  A    1 P 00:000:00000 00:000:00000 V -
+ OUAG  A    1 P 00:000:00000 00:000:00000 P -
+ OUAG  A    1 P 00:000:00000 00:000:00000 V -
+ OUSD  A    1 P 00:000:00000 03:233:43970 P - EQ M7.2 - South Island of New Zealand
+ OUSD  A    2 P 03:233:43970 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ OUSD  A    3 P 04:358:53944 06:171:43200 P - antenna change
+ OUSD  A    4 P 06:171:43200 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ OUSD  A    5 P 09:196:33749 11:206:41400 P - antenna change
+ OUSD  A    6 P 11:206:41400 16:318:00000 P -
+ OUSD  A    7 P 16:318:00000 00:000:00000 P -
+ OUSD  A    1 P 00:000:00000 00:000:00000 V -
+ OXEC  A    1 P 00:000:00000 12:032:00000 P - unknown
+ OXEC  A    2 P 12:032:00000 12:080:64968 P - EQ M7.4 - Oaxaca, Mexico
+ OXEC  A    3 P 12:080:64968 00:000:00000 P -
+ OXEC  A    1 P 00:000:00000 00:000:00000 V -
+ P059  A    1 P 00:000:00000 00:000:00000 P -
+ P059  A    1 P 00:000:00000 00:000:00000 V -
+ P101  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P101  A    2 P 03:268:71406 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P101  A    3 P 11:070:20783 00:000:00000 P -
+ P101  A    1 P 00:000:00000 00:000:00000 V -
+ P102  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P102  A    2 P 03:268:71406 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P102  A    3 P 11:070:20783 00:000:00000 P -
+ P102  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P102  A    2 P 11:070:20783 00:000:00000 V -
+ P103  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P103  A    2 P 03:268:71406 08:364:00000 P - unknown
+ P103  A    3 P 08:364:00000 09:118:00000 P - unknown
+ P103  A    4 P 09:118:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P103  A    5 P 11:070:20783 00:000:00000 P -
+ P103  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P103  A    2 P 11:070:20783 00:000:00000 V -
+ P104  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P104  A    2 P 03:268:71406 08:165:85425 P - EQ M6.9 - eastern Honshu, Japan
+ P104  A    3 P 08:165:85425 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P104  A    4 P 11:070:20783 00:000:00000 P -
+ P104  A    1 P 00:000:00000 00:000:00000 V -
+ P105  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P105  A    2 P 03:268:71406 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P105  A    3 P 04:249:53839 05:228:09988 P - EQ M7.2 - near the east coast of Honshu, Japan
+ P105  A    4 P 05:228:09988 07:024:00000 P - antenna change
+ P105  A    5 P 07:024:00000 08:165:85425 P - EQ M6.9 - eastern Honshu, Japan
+ P105  A    6 P 08:165:85425 10:073:29284 P - EQ M6.5 - near the east coast of Honshu, Japan
+ P105  A    7 P 10:073:29284 11:041:00000 P - unknown
+ P105  A    8 P 11:041:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P105  A    9 P 11:070:20783 00:000:00000 P -
+ P105  A    1 P 00:000:00000 00:000:00000 V -
+ P106  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P106  A    2 P 03:268:71406 03:304:03988 P - EQ M7.0 - off the east coast of Honshu, Japan
+ P106  A    3 P 03:304:03988 05:228:09988 P - EQ M7.2 - near the east coast of Honshu, Japan
+ P106  A    4 P 05:228:09988 08:128:60320 P - EQ M6.9 - near the east coast of Honshu, Japan
+ P106  A    5 P 08:128:60320 08:201:09569 P - EQ M7.0 - off the east coast of Honshu, Japan
+ P106  A    6 P 08:201:09569 10:073:29284 P - EQ M6.5 - near the east coast of Honshu, Japan
+ P106  A    7 P 10:073:29284 10:352:00000 P - unknown
+ P106  A    8 P 10:352:00000 11:068:09920 P - EQ M7.3 - near the east coast of Honshu, Japan
+ P106  A    9 P 11:068:09920 00:000:00000 P -
+ P106  A    1 P 00:000:00000 05:228:09988 V - EQ M7.2 - near the east coast of Honshu, Japan
+ P106  A    2 P 05:228:09988 08:201:09569 V - EQ M7.0 - off the east coast of Honshu, Japan
+ P106  A    3 P 08:201:09569 10:073:29284 V - EQ M6.5 - near the east coast of Honshu, Japan
+ P106  A    4 P 10:073:29284 00:000:00000 V -
+ P107  A    1 P 00:000:00000 07:230:00000 P - unknown
+ P107  A    2 P 07:230:00000 09:353:00000 P - unknown
+ P107  A    3 P 09:353:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P107  A    4 P 11:070:20783 11:191:03431 P - EQ M7.0 - off the east coast of Honshu, Japan
+ P107  A    5 P 11:191:03431 11:301:00000 P - unknown
+ P107  A    6 P 11:301:00000 13:298:61820 P - EQ M7.1 - Off the east coast of Honshu, Japan
+ P107  A    7 P 13:298:61820 00:000:00000 P -
+ P107  A    1 P 00:000:00000 00:000:00000 V -
+ P108  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P108  A    2 P 04:249:53839 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P108  A    3 P 11:070:20783 00:000:00000 P -
+ P108  A    1 P 00:000:00000 00:000:00000 V -
+ P109  A    1 P 00:000:00000 03:264:00000 P - unknown
+ P109  A    2 P 03:264:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P109  A    3 P 04:249:53839 04:297:32161 P - EQ M6.6 - near the west coast of Honshu, Japan
+ P109  A    4 P 04:297:32161 07:197:04402 P - EQ M6.6 - near the west coast of Honshu, Japan
+ P109  A    5 P 07:197:04402 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P109  A    6 P 11:070:20783 00:000:00000 P -
+ P109  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P109  A    2 P 11:070:20783 00:000:00000 V -
+ P110  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P110  A    2 P 04:249:53839 04:297:32161 P - EQ M6.6 - near the west coast of Honshu, Japan
+ P110  A    3 P 04:297:32161 07:197:04402 P - EQ M6.6 - near the west coast of Honshu, Japan
+ P110  A    4 P 07:197:04402 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P110  A    5 P 11:070:20783 00:000:00000 P -
+ P110  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P110  A    2 P 11:070:20783 00:000:00000 V -
+ P111  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P111  A    2 P 04:249:53839 07:084:02518 P - EQ M6.7 - near the west coast of Honshu, Japan
+ P111  A    3 P 07:084:02518 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P111  A    4 P 11:070:20783 00:000:00000 P -
+ P111  A    1 P 00:000:00000 00:000:00000 V -
+ P112  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P112  A    2 P 04:249:53839 08:329:00000 P - unknown
+ P112  A    3 P 08:329:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P112  A    4 P 11:070:20783 00:000:00000 P -
+ P112  A    1 P 00:000:00000 00:000:00000 V -
+ P113  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P113  A    2 P 04:249:53839 06:111:00000 P - unknown
+ P113  A    3 P 06:111:00000 09:352:00000 P - unknown
+ P113  A    4 P 09:352:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P113  A    5 P 11:070:20783 00:000:00000 P -
+ P113  A    1 P 00:000:00000 06:111:00000 V - unknown
+ P113  A    2 P 06:111:00000 09:352:00000 V - unknown
+ P113  A    3 P 09:352:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P113  A    4 P 11:070:20783 00:000:00000 V -
+ P114  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P114  A    2 P 04:249:53839 09:223:00000 P - unknown
+ P114  A    3 P 09:223:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P114  A    4 P 11:070:20783 00:000:00000 P -
+ P114  A    1 P 00:000:00000 00:000:00000 V -
+ P115  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P115  A    2 P 04:249:53839 09:223:00000 P - unknown
+ P115  A    3 P 09:223:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P115  A    4 P 11:070:20783 00:000:00000 P -
+ P115  A    1 P 00:000:00000 00:000:00000 V -
+ P116  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P116  A    2 P 04:249:53839 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P116  A    3 P 11:070:20783 00:000:00000 P -
+ P116  A    1 P 00:000:00000 00:000:00000 V -
+ P117  A    1 P 00:000:00000 04:249:36428 P - EQ M7.2 - near the south coast of western Honshu, Japan
+ P117  A    2 P 04:249:36428 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P117  A    3 P 11:070:20783 00:000:00000 P -
+ P117  A    1 P 00:000:00000 00:000:00000 V -
+ P118  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P118  A    2 P 04:249:53839 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P118  A    3 P 11:070:20783 00:000:00000 P -
+ P118  A    1 P 00:000:00000 00:000:00000 V -
+ P119  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ P119  A    2 P 04:361:03530 05:079:06822 P - EQ M6.6 - Kyushu, Japan
+ P119  A    3 P 05:079:06822 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P119  A    4 P 11:070:20783 00:000:00000 P -
+ P119  A    1 P 00:000:00000 00:000:00000 V -
+ P120  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P120  A    2 P 04:249:53839 06:229:00000 P - non linearity
+ P120  A    3 P 06:229:00000 10:083:00000 P - non linearity
+ P120  A    4 P 10:083:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P120  A    5 P 11:070:20783 00:000:00000 P - 
+ P120  A    1 P 00:000:00000 04:249:53839 V - EQ M7.4 - near the south coast of Honshu, Japan
+ P120  A    2 P 04:249:53839 06:229:00000 V - non linearity
+ P120  A    3 P 06:229:00000 10:083:00000 V - non linearity
+ P120  A    4 P 10:083:00000 00:000:00000 V - 
+ P121  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ P121  A    2 P 04:361:03530 05:079:06822 P - EQ M6.6 - Kyushu, Japan
+ P121  A    3 P 05:079:06822 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P121  A    4 P 11:070:20783 00:000:00000 P -
+ P121  A    1 P 00:000:00000 00:000:00000 V -
+ P122  A    1 P 00:000:00000 04:251:00000 P - unknown
+ P122  A    2 P 04:251:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P122  A    3 P 11:070:20783 00:000:00000 P -
+ P122  A    1 P 00:000:00000 00:000:00000 V -
+ P123  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P123  A    2 P 11:070:20783 00:000:00000 P -
+ P123  A    1 P 00:000:00000 00:000:00000 V -
+ P124  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ P124  A    2 P 04:361:03530 10:057:73887 P - EQ M7.0 - Ryukyu Islands, Japan
+ P124  A    3 P 10:057:73887 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P124  A    4 P 11:070:20783 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ P124  A    5 P 12:102:31117 00:000:00000 P -
+ P124  A    1 P 00:000:00000 00:000:00000 V -
+ P162  A    1 P 00:000:00000 05:166:10253 P - EQ M7.2 - off the coast of Northern California
+ P162  A    2 P 05:166:10253 10:010:01659 P - EQ M6.5 - offshore Northern California
+ P162  A    3 P 10:010:01659 00:000:00000 P -
+ P162  A    1 P 00:000:00000 10:010:01659 V - EQ M6.5 - offshore Northern California
+ P162  A    2 P 10:010:01659 00:000:00000 V -
+ P201  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P201  A    2 P 03:268:71406 06:319:40458 P - EQ M8.3 - Kuril Islands
+ P201  A    3 P 06:319:40458 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P201  A    4 P 11:070:20783 13:144:20689 P - EQ M8.3 - Sea of Okhotsk
+ P201  A    5 P 13:144:20689 00:000:00000 P -
+ P201  A    1 P 00:000:00000 03:268:71406 V - EQ M8.3 - Hokkaido, Japan region
+ P201  A    2 P 03:268:71406 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P201  A    3 P 11:070:20783 00:000:00000 V -
+ P202  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P202  A    2 P 03:268:71406 04:333:66734 P - EQ M7.0 - Hokkaido, Japan region
+ P202  A    3 P 04:333:66734 04:341:51312 P - EQ M6.8 - Hokkaido, Japan region
+ P202  A    4 P 04:341:51312 06:319:40458 P - EQ M8.3 - Kuril Islands
+ P202  A    5 P 06:319:40458 07:013:15801 P - EQ M8.1 - east of the Kuril Islands
+ P202  A    6 P 07:013:15801 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P202  A    7 P 11:070:20783 13:033:51455 P - EQ M6.9 - 19km SSW of Obihiro, Japan
+ P202  A    8 P 13:033:51455 00:000:00000 P -
+ P202  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P202  A    2 P 11:070:20783 00:000:00000 V -
+ P203  A    1 P 00:000:00000 03:129:00000 P - unknown
+ P203  A    2 P 03:129:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P203  A    3 P 03:268:71406 03:281:32815 P - EQ M6.7 - Hokkaido, Japan region
+ P203  A    4 P 03:281:32815 04:333:66734 P - EQ M7.0 - Hokkaido, Japan region
+ P203  A    5 P 04:333:66734 04:341:51312 P - EQ M6.8 - Hokkaido, Japan region
+ P203  A    6 P 04:341:51312 06:319:40458 P - EQ M8.3 - Kuril Islands
+ P203  A    7 P 06:319:40458 07:013:15801 P - EQ M8.1 - east of the Kuril Islands
+ P203  A    8 P 07:013:15801 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P203  A    9 P 11:070:20783 00:000:00000 P -
+ P203  A    1 P 00:000:00000 00:000:00000 V -
+ P204  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ P204  A    2 P 03:268:71406 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P204  A    3 P 11:070:20783 00:000:00000 P -
+ P204  A    1 P 00:000:00000 00:000:00000 V -
+ P206  A    1 P 00:000:00000 04:154:00000 P - unknown
+ P206  A    2 P 04:154:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P206  A    3 P 04:249:53839 06:120:00000 P - non linearity
+ P206  A    4 P 06:120:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P206  A    5 P 11:070:20783 00:000:00000 P - 
+ P206  A    1 P 00:000:00000 04:249:53839 V - EQ M7.4 - near the south coast of Honshu, Japan
+ P206  A    2 P 04:249:53839 06:120:00000 V - non linearity
+ P206  A    3 P 06:120:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P206  A    4 P 11:070:20783 00:000:00000 V - 
+ P207  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ P207  A    2 P 04:249:53839 07:084:02518 P - EQ M6.7 - near the west coast of Honshu, Japan
+ P207  A    3 P 07:084:02518 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P207  A    4 P 11:070:20783 00:000:00000 P -
+ P207  A    1 P 00:000:00000 00:000:00000 V -
+ P208  A    1 P 00:000:00000 04:249:36428 P - EQ M7.2 - near the south coast of western Honshu, Japan
+ P208  A    2 P 04:249:36428 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P208  A    3 P 11:070:20783 00:000:00000 P -
+ P208  A    1 P 00:000:00000 04:249:36428 V - EQ M7.2 - near the south coast of western Honshu, Japan
+ P208  A    2 P 04:249:36428 00:000:00000 V -
+ P209  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ P209  A    2 P 04:361:03530 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P209  A    3 P 11:070:20783 00:000:00000 P -
+ P209  A    1 P 00:000:00000 00:000:00000 V -
+ P210  A    1 P 00:000:00000 07:321:00000 P - unknown
+ P210  A    2 P 07:321:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P210  A    3 P 11:070:20783 00:000:00000 P -
+ P210  A    1 P 00:000:00000 00:000:00000 V -
+ P211  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P211  A    2 P 11:070:20783 00:000:00000 P -
+ P211  A    1 P 00:000:00000 11:070:20783 V - EQ M9.0 - near the east coast of Honshu, Japan
+ P211  A    2 P 11:070:20783 00:000:00000 V -
+ P212  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ P212  A    2 P 04:361:03530 10:057:73887 P - EQ M7.0 - Ryukyu Islands, Japan
+ P212  A    3 P 10:057:73887 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ P212  A    4 P 11:070:20783 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ P212  A    5 P 12:102:31117 00:000:00000 P -
+ P212  A    1 P 00:000:00000 00:000:00000 V -
+ P213  A    1 P 00:000:00000 08:058:24861 P - EQ M6.2 - Bonin Islands, Japan region
+ P213  A    2 P 08:058:24861 10:355:62381 P - EQ M7.4 - Bonin Islands, Japan region
+ P213  A    3 P 10:355:62381 00:000:00000 P -
+ P213  A    1 P 00:000:00000 08:058:24861 V - EQ M6.2 - Bonin Islands, Japan region
+ P213  A    2 P 08:058:24861 00:000:00000 V -
+ P224  A    1 P 00:000:00000 00:000:00000 P -
+ P224  A    1 P 00:000:00000 00:000:00000 V -
+ P231  A    1 P 00:000:00000 11:129:50400 P - antenna change
+ P231  A    2 P 11:129:50400 00:000:00000 P -
+ P231  A    1 P 00:000:00000 00:000:00000 V -
+ P365  A    1 P 00:000:00000 00:000:00000 P -
+ P365  A    1 P 00:000:00000 00:000:00000 V -
+ P435  A    1 P 00:000:00000 08:067:00000 P - antenna change
+ P435  A    2 P 08:067:00000 09:108:00000 P - antenna change
+ P435  A    3 P 09:108:00000 00:000:00000 P -
+ P435  A    1 P 00:000:00000 00:000:00000 V -
+ PADO  A    1 P 00:000:00000 13:256:36000 P - antenna change
+ PADO  A    2 P 13:256:36000 00:000:00000 P -
+ PADO  A    1 P 00:000:00000 00:000:00000 V -
+ PALK  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ PALK  A    2 P 12:102:31117 00:000:00000 P -
+ PALK  A    1 P 00:000:00000 00:000:00000 V -
+ PALM  A    1 P 00:000:00000 99:125:00000 P - unknown
+ PALM  A    2 P 99:125:00000 05:166:00000 P - non linearity
+ PALM  A    3 P 05:166:00000 07:214:00000 P - non linearity
+ PALM  A    4 P 07:214:00000 13:321:32696 P - EQ M7.7 - Scotia Sea
+ PALM  A    5 P 13:321:32696 00:000:00000 P - 
+ PALM  A    1 P 00:000:00000 05:166:00000 V - non linearity
+ PALM  A    2 P 05:166:00000 07:214:00000 V - non linearity
+ PALM  A    3 P 07:214:00000 00:000:00000 V - 
+ PALV  A    1 P 00:000:00000 13:321:32696 P - EQ M7.7 - Scotia Sea
+ PALV  A    2 P 13:321:32696 00:000:00000 P -
+ PALV  A    1 P 00:000:00000 00:000:00000 V -
+ PAPE  A    1 P 00:000:00000 00:000:00000 P -
+ PAPE  A    1 P 00:000:00000 00:000:00000 V -
+ PAPH  A    1 P 00:000:00000 00:000:00000 P -
+ PAPH  A    1 P 00:000:00000 00:000:00000 V -
+ PARA  A    1 P 00:000:00000 00:000:00000 P -
+ PARA  A    1 P 00:000:00000 00:000:00000 V -
+ PARK  A    1 P 00:000:00000 10:320:00000 P - unknown
+ PARK  A    2 P 10:320:00000 00:000:00000 P -
+ PARK  A    1 P 00:000:00000 00:000:00000 V -
+ PASA  A    1 P 00:000:00000 07:201:00000 P - unknown
+ PASA  A    2 P 07:201:00000 07:248:00000 P - unknown
+ PASA  A    3 P 07:248:00000 11:157:00000 P - unknown
+ PASA  A    4 P 11:157:00000 00:000:00000 P -
+ PASA  A    1 P 00:000:00000 00:000:00000 V -
+ PASO  A    1 P 00:000:00000 00:000:00000 P -
+ PASO  A    1 P 00:000:00000 00:000:00000 V -
+ PAT0  A    1 P 00:000:00000 10:018:57369 P - EQ M5.5 - Greece
+ PAT0  A    2 P 10:018:57369 00:000:00000 P -
+ PAT0  A    1 P 00:000:00000 00:000:00000 V -
+ PATT  A    1 P 00:000:00000 00:000:00000 P -
+ PATT  A    1 P 00:000:00000 00:000:00000 V -
+ PBAI  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ PBAI  A    2 P 04:361:03530 05:087:58177 P - EQ M8.6 - northern Sumatra, Indonesia
+ PBAI  A    3 P 05:087:58177 05:134:18319 P - EQ M6.7 - Nias region, Indonesia
+ PBAI  A    4 P 05:134:18319 00:000:00000 P -
+ PBAI  A    1 P 00:000:00000 00:000:00000 V -
+ PBIL  A    1 P 00:000:00000 00:000:00000 P -
+ PBIL  A    1 P 00:000:00000 00:000:00000 V -
+ PBL1  A    1 P 00:000:00000 96:012:00000 P - unknown
+ PBL1  A    2 P 96:012:00000 00:000:00000 P -
+ PBL1  A    1 P 00:000:00000 00:000:00000 V -
+ PBR2  A    1 P 00:000:00000 11:126:00000 P - unknown
+ PBR2  A    2 P 11:126:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ PBR2  A    3 P 12:102:31117 00:000:00000 P -
+ PBR2  A    1 P 00:000:00000 00:000:00000 V -
+ PBRI  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ PBRI  A    2 P 12:102:31117 00:000:00000 P -
+ PBRI  A    1 P 00:000:00000 00:000:00000 V -
+ PCLA  A    1 P 00:000:00000 00:000:00000 P -
+ PCLA  A    1 P 00:000:00000 00:000:00000 V -
+ PENC  A    1 P 00:000:00000 03:142:00000 P - antenna change
+ PENC  A    2 P 03:142:00000 07:193:00000 P - antenna change
+ PENC  A    3 P 07:193:00000 00:000:00000 P -
+ PENC  A    1 P 00:000:00000 00:000:00000 V -
+ PETP  A    1 P 00:000:00000 99:067:44749 P - EQ M6.9 - off the east coast of the Kamchatka Peninsula, Russia
+ PETP  A    2 P 99:067:44749 03:338:00000 P - unknown
+ PETP  A    3 P 03:338:00000 05:057:00000 P - unknown
+ PETP  A    4 P 05:057:00000 05:307:00000 P - unknown
+ PETP  A    5 P 05:307:00000 07:013:15801 P - EQ M8.1 - east of the Kuril Islands
+ PETP  A    6 P 07:013:15801 07:180:00000 P - unknown
+ PETP  A    7 P 07:180:00000 00:000:00000 P -
+ PETP  A    1 P 00:000:00000 03:338:00000 V - unknown
+ PETP  A    2 P 03:338:00000 07:013:15801 V - EQ M8.1 - east of the Kuril Islands
+ PETP  A    3 P 07:013:15801 00:000:00000 V -
+ PETS  A    1 P 00:000:00000 05:112:00000 P - unknown
+ PETS  A    2 P 05:112:00000 05:279:00000 P - antenna change
+ PETS  A    3 P 05:279:00000 07:013:15801 P - EQ M8.1 - east of the Kuril Islands
+ PETS  A    4 P 07:013:15801 11:294:00000 P - receiver change
+ PETS  A    5 P 11:294:00000 13:144:20689 P - EQ M8.3 - Sea of Okhotsk
+ PETS  A    6 P 13:144:20689 16:027:00000 P -
+ PETS  A    7 P 16:027:00000 00:000:00000 P -
+ PETS  A    1 P 00:000:00000 07:013:15801 V - EQ M8.1 - east of the Kuril Islands
+ PETS  A    2 P 07:013:15801 13:144:20689 V - EQ M8.3 - Sea of Okhotsk
+ PETS  A    3 P 13:144:20689 00:000:00000 V -
+ PGC5  A    1 P 00:000:00000 00:252:84780 P - antenna change
+ PGC5  A    2 P 00:252:84780 01:290:00000 P - unknown
+ PGC5  A    3 P 01:290:00000 01:353:00000 P - unknown
+ PGC5  A    4 P 01:353:00000 05:294:62700 P - antenna change
+ PGC5  A    5 P 05:294:62700 00:000:00000 P -
+ PGC5  A    1 P 00:000:00000 00:000:00000 V -
+ PHLW  A    1 P 00:000:00000 00:000:00000 P -
+ PHLW  A    1 P 00:000:00000 00:000:00000 V -
+ PICL  A    1 P 00:000:00000 04:352:57600 P - antenna change
+ PICL  A    2 P 04:352:57600 00:000:00000 P -
+ PICL  A    1 P 00:000:00000 00:000:00000 V -
+ PIMO  A    1 P 00:000:00000 99:345:65017 P - EQ M7.3 - Luzon, Philippines
+ PIMO  A    2 P 99:345:65017 01:249:00000 P - antenna change
+ PIMO  A    3 P 01:249:00000 02:318:00000 P - non linearity
+ PIMO  A    4 P 02:318:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ PIMO  A    5 P 04:361:03530 05:265:00000 P - antenna change
+ PIMO  A    6 P 05:265:00000 09:050:00000 P - receiver change
+ PIMO  A    7 P 09:050:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ PIMO  A    8 P 12:102:31117 12:244:46053 P - EQ M7.6 - Philippine Islands region
+ PIMO  A    9 P 12:244:46053 00:000:00000 P - 
+ PIMO  A    1 P 00:000:00000 99:345:65017 V - EQ M7.3 - Luzon, Philippines
+ PIMO  A    2 P 99:345:65017 02:318:00000 V - non linearity
+ PIMO  A    3 P 02:318:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ PIMO  A    4 P 04:361:03530 09:050:00000 V - receiver change
+ PIMO  A    5 P 09:050:00000 12:102:31117 V - EQ M8.6 - off the west coast of northern Sumatra
+ PIMO  A    6 P 12:102:31117 00:000:00000 V - 
+ PIN1  A    1 P 00:000:00000 95:214:00000 P - antenna change
+ PIN1  A    2 P 95:214:00000 97:024:00000 P - antenna change
+ PIN1  A    3 P 97:024:00000 99:289:35204 P - EQ M7.1 - Southern California
+ PIN1  A    4 P 99:289:35204 01:059:00000 P - antenna change
+ PIN1  A    5 P 01:059:00000 04:227:00000 P - antenna change
+ PIN1  A    6 P 04:227:00000 04:254:12600 P - antenna change
+ PIN1  A    7 P 04:254:12600 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ PIN1  A    8 P 10:094:81643 00:000:00000 P -
+ PIN1  A    1 P 00:000:00000 00:000:00000 V -
+ PIN2  A    1 P 00:000:00000 98:297:00000 P - unknown
+ PIN2  A    2 P 98:297:00000 00:000:00000 P -
+ PIN2  A    1 P 00:000:00000 00:000:00000 V -
+ PKDB  A    1 P 00:000:00000 99:209:00000 P - antenna change
+ PKDB  A    2 P 99:209:00000 00:000:00000 P -
+ PKDB  A    1 P 00:000:00000 00:000:00000 V -
+ PLO5  A    1 P 00:000:00000 09:216:00000 P - unknown
+ PLO5  A    2 P 09:216:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ PLO5  A    3 P 10:094:81643 00:000:00000 P -
+ PLO5  A    1 P 00:000:00000 00:000:00000 V -
+ PLPK  A    1 P 00:000:00000 10:090:00000 P - non linearity
+ PLPK  A    2 P 10:090:00000 12:241:00000 P - unknown
+ PLPK  A    3 P 12:241:00000 12:263:00000 P - unknown
+ PLPK  A    4 P 12:263:00000 00:000:00000 P - 
+ PLPK  A    1 P 00:000:00000 10:090:00000 V - non linearity
+ PLPK  A    2 P 10:090:00000 00:000:00000 V - 
+ PLTC  A    1 P 00:000:00000 00:000:00000 P -
+ PLTC  A    1 P 00:000:00000 00:000:00000 V -
+ PLUZ  A    1 P 00:000:00000 00:000:00000 P -
+ PLUZ  A    1 P 00:000:00000 00:000:00000 V -
+ PMTG  A    1 P 00:000:00000 04:095:00000 P - unknown
+ PMTG  A    2 P 04:095:00000 05:293:00000 P - receiver change
+ PMTG  A    3 P 05:293:00000 06:131:43200 P - receiver change
+ PMTG  A    4 P 06:131:43200 00:000:00000 P -
+ PMTG  A    1 P 00:000:00000 00:000:00000 V -
+ PMTH  A    1 P 00:000:00000 09:035:46200 P - antenna change
+ PMTH  A    2 P 09:035:46200 00:000:00000 P -
+ PMTH  A    1 P 00:000:00000 00:000:00000 V -
+ PNCY  A    1 P 00:000:00000 00:000:00000 P -
+ PNCY  A    1 P 00:000:00000 00:000:00000 V -
+ PNGM  A    1 P 00:000:00000 02:251:67464 P - EQ M7.6 - near the north coast of New Guinea, Papua New Guinea
+ PNGM  A    2 P 02:251:67464 08:158:00000 P - non linearity
+ PNGM  A    3 P 08:158:00000 10:199:48899 P - EQ M7.3 - New Britain region, Papua New Guinea
+ PNGM  A    4 P 10:199:48899 12:252:00000 P - antenna change
+ PNGM  A    5 P 12:252:00000 00:000:00000 P - 
+ PNGM  A    1 P 00:000:00000 08:158:00000 V - non linearity
+ PNGM  A    2 P 08:158:00000 00:000:00000 V - 
+ POAL  A    1 P 00:000:00000 07:115:00000 P - antenna change
+ POAL  A    2 P 07:115:00000 07:254:00000 P - antenna change
+ POAL  A    3 P 07:254:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ POAL  A    4 P 10:058:23652 13:134:54120 P - antenna change
+ POAL  A    5 P 13:134:54120 00:000:00000 P -
+ POAL  A    1 P 00:000:00000 00:000:00000 V -
+ POR2  A    1 P 00:000:00000 98:328:00000 P - unknown
+ POR2  A    2 P 98:328:00000 00:000:00000 P -
+ POR2  A    1 P 00:000:00000 00:000:00000 V -
+ POR4  A    1 P 00:000:00000 99:165:00000 P - antenna change
+ POR4  A    2 P 99:165:00000 99:208:00000 P - antenna change
+ POR4  A    3 P 99:208:00000 00:000:00000 P -
+ POR4  A    1 P 00:000:00000 00:000:00000 V -
+ POTR  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ POTR  A    2 P 10:094:81643 00:000:00000 P -
+ POTR  A    1 P 00:000:00000 00:000:00000 V -
+ POVE  A    1 P 00:000:00000 00:000:00000 P -
+ POVE  A    1 P 00:000:00000 00:000:00000 V -
+ PPT1  A    1 P 00:000:00000 00:000:00000 P -
+ PPT1  A    1 P 00:000:00000 00:000:00000 V -
+ PPTE  A    1 P 00:000:00000 09:250:00000 P - antenna change
+ PPTE  A    2 P 09:250:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ PPTE  A    3 P 10:058:23652 00:000:00000 P -
+ PPTE  A    1 P 00:000:00000 00:000:00000 V -
+ PRCO  A    1 P 00:000:00000 96:018:00000 P - antenna change
+ PRCO  A    2 P 96:018:00000 96:025:00000 P - antenna change
+ PRCO  A    3 P 96:025:00000 96:168:00000 P - unknown
+ PRCO  A    4 P 96:168:00000 99:360:64800 P - antenna change
+ PRCO  A    5 P 99:360:64800 00:000:00000 P -
+ PRCO  A    1 P 00:000:00000 00:000:00000 V -
+ PRE2  A    1 P 00:000:00000 06:037:00000 P - unknown
+ PRE2  A    2 P 06:037:00000 06:339:00000 P - unknown
+ PRE2  A    3 P 06:339:00000 07:049:00000 P - unknown
+ PRE2  A    4 P 07:049:00000 07:130:00000 P - unknown
+ PRE2  A    5 P 07:130:00000 00:000:00000 P -
+ PRE2  A    1 P 00:000:00000 00:000:00000 V -
+ PRIE  A    1 P 00:000:00000 09:188:00000 P - antenna change
+ PRIE  A    2 P 09:188:00000 12:342:32400 P - antenna change
+ PRIE  A    3 P 12:342:32400 00:000:00000 P -
+ PRIE  A    1 P 00:000:00000 00:000:00000 V -
+ PRMI  A    1 P 00:000:00000 00:000:00000 P -
+ PRMI  A    1 P 00:000:00000 00:000:00000 V -
+ PTAG  A    1 P 00:000:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ PTAG  A    2 P 12:102:31117 12:244:46053 P - EQ M7.6 - Philippine Islands region
+ PTAG  A    3 P 12:244:46053 00:000:00000 P -
+ PTAG  A    1 P 00:000:00000 00:000:00000 V -
+ PTBB  A    1 P 00:000:00000 00:000:00000 P -
+ PTBB  A    1 P 00:000:00000 00:000:00000 V -
+ PTKL  A    1 P 00:000:00000 00:000:00000 P -
+ PTKL  A    1 P 00:000:00000 00:000:00000 V -
+ PTLD  A    1 P 00:000:00000 12:032:00000 P - unknown
+ PTLD  A    2 P 12:032:00000 12:123:00000 P - unknown
+ PTLD  A    3 P 12:123:00000 17:179:00000 P -
+ PTLD  A    4 P 17:179:00000 18:122:00000 P - Radome distroied 
+ PTLD  A    5 P 18:122:00000 00:000:00000 P -
+ PTLD  A    1 P 00:000:00000 00:000:00000 V -
+ PTRB  A    1 P 00:000:00000 99:244:78300 P - antenna change
+ PTRB  A    2 P 99:244:78300 11:245:54300 P - receiver change
+ PTRB  A    3 P 11:245:54300 00:000:00000 P -
+ PTRB  A    1 P 00:000:00000 00:000:00000 V -
+ PTSG  A    1 P 00:000:00000 05:166:10253 P - EQ M7.2 - off the coast of Northern California
+ PTSG  A    2 P 05:166:10253 09:034:00000 P - antenna change
+ PTSG  A    3 P 09:034:00000 09:077:00000 P - antenna change
+ PTSG  A    4 P 09:077:00000 10:010:01659 P - EQ M6.5 - offshore Northern California
+ PTSG  A    5 P 10:010:01659 00:000:00000 P -
+ PTSG  A    1 P 00:000:00000 00:000:00000 V -
+ PTSV  A    1 P 00:000:00000 10:313:00000 P - antenna change
+ PTSV  A    2 P 10:313:00000 00:000:00000 P -
+ PTSV  A    1 P 00:000:00000 00:000:00000 V -
+ PUR3  A    1 P 00:000:00000 00:000:00000 P -
+ PUR3  A    1 P 00:000:00000 00:000:00000 V -
+ PUR5  A    1 P 00:000:00000 00:000:00000 P -
+ PUR5  A    1 P 00:000:00000 00:000:00000 V -
+ PUR6  A    1 P 00:000:00000 00:000:00000 P -
+ PUR6  A    1 P 00:000:00000 00:000:00000 V -
+ PVE3  A    1 P 00:000:00000 03:094:00000 P - antenna change
+ PVE3  A    2 P 03:094:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ PVE3  A    3 P 10:094:81643 12:286:65820 P - antenna change
+ PVE3  A    4 P 12:286:65820 00:000:00000 P -
+ PVE3  A    1 P 00:000:00000 00:000:00000 V -
+ PVEP  A    1 P 00:000:00000 94:017:45055 P - EQ M6.7 - Greater Los Angeles area, California
+ PVEP  A    2 P 94:017:45055 98:003:00000 P - antenna change
+ PVEP  A    3 P 98:003:00000 98:013:00000 P - receiver change
+ PVEP  A    4 P 98:013:00000 99:289:35204 P - EQ M7.1 - Southern California
+ PVEP  A    5 P 99:289:35204 00:000:00000 P -
+ PVEP  A    1 P 00:000:00000 00:000:00000 V -
+ QAAR  A    1 P 00:000:00000 10:111:00000 P - non linearity
+ QAAR  A    2 P 10:111:00000 00:000:00000 P - 
+ QAAR  A    1 P 00:000:00000 10:111:00000 V - non linearity
+ QAAR  A    2 P 10:111:00000 00:000:00000 V - 
+ QUAD  A    1 P 00:000:00000 00:000:00000 P -
+ QUAD  A    1 P 00:000:00000 00:000:00000 V -
+ QUAR  A    1 P 00:000:00000 00:035:00000 P - antenna change
+ QUAR  A    2 P 00:035:00000 00:069:00000 P - unknown
+ QUAR  A    3 P 00:069:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ QUAR  A    4 P 04:358:53944 09:196:33749 P - EQ M7.8 - off the west coast of the South Island of New Zealand
+ QUAR  A    5 P 09:196:33749 10:246:59748 P - EQ M7.0 - South Island of New Zealand
+ QUAR  A    6 P 10:246:59748 00:000:00000 P -
+ QUAR  A    1 P 00:000:00000 00:000:00000 V -
+ QUI1  A    1 P 00:000:00000 04:001:00000 P - unknown
+ QUI1  A    2 P 04:001:00000 00:000:00000 P -
+ QUI1  A    1 P 00:000:00000 00:000:00000 V -
+ QUI2  A    1 P 00:000:00000 00:000:00000 P -
+ QUI2  A    1 P 00:000:00000 00:000:00000 V -
+ RBAY  A    1 P 00:000:00000 12:337:00000 P - antenna change
+ RBAY  A    2 P 12:337:00000 00:000:00000 P -
+ RBAY  A    1 P 00:000:00000 00:000:00000 V -
+ RCA2  A    1 P 00:000:00000 03:194:00000 P - unknown
+ RCA2  A    2 P 03:194:00000 04:041:00000 P - antenna change
+ RCA2  A    3 P 04:041:00000 00:000:00000 P -
+ RCA2  A    1 P 00:000:00000 00:000:00000 V -
+ RCM5  A    1 P 00:000:00000 96:048:00000 P - unknown
+ RCM5  A    2 P 96:048:00000 00:000:00000 P -
+ RCM5  A    1 P 00:000:00000 00:000:00000 V -
+ RCMV  A    1 P 00:000:00000 00:000:00000 P -
+ RCMV  A    1 P 00:000:00000 00:000:00000 V -
+ RED5  A    1 P 00:000:00000 00:000:00000 P -
+ RED5  A    1 P 00:000:00000 00:000:00000 V -
+ REDU  A    1 P 00:000:00000 13:254:50400 P - antenna change
+ REDU  A    2 P 13:254:50400 00:000:00000 P -
+ REDU  A    1 P 00:000:00000 00:000:00000 V -
+ REDZ  A    1 P 00:000:00000 14:302:41400 P - antenna change
+ REDZ  A    2 P 14:302:41400 00:000:00000 P -
+ REDZ  A    1 P 00:000:00000 00:000:00000 V -
+ REYK  A    1 P 00:000:00000 00:169:56442 P - EQ M6.5 - Iceland
+ REYK  A    2 P 00:169:56442 00:173:03107 P - EQ M6.5 - Iceland
+ REYK  A    3 P 00:173:03107 03:164:54000 P - antenna change
+ REYK  A    4 P 03:164:54000 07:263:59400 P - antenna change
+ REYK  A    5 P 07:263:59400 08:073:62820 P - antenna change
+ REYK  A    6 P 08:073:62820 08:150:56761 P - EQ M6.3 - Iceland
+ REYK  A    7 P 08:150:56761 13:122:46800 P - antenna change
+ REYK  A    8 P 13:122:46800 00:000:00000 P -
+ REYK  A    1 P 00:000:00000 00:000:00000 V -
+ REYZ  A    1 P 00:000:00000 00:169:56442 P - EQ M6.5 - Iceland
+ REYZ  A    2 P 00:169:56442 00:173:03107 P - EQ M6.5 - Iceland
+ REYZ  A    3 P 00:173:03107 03:233:49800 P - antenna change
+ REYZ  A    4 P 03:233:49800 00:000:00000 P -
+ REYZ  A    1 P 00:000:00000 00:000:00000 V -
+ RIC1  A    1 P 00:000:00000 00:000:00000 P -
+ RIC1  A    1 P 00:000:00000 00:000:00000 V -
+ RINK  A    1 P 00:000:00000 10:117:00000 P - non linearity
+ RINK  A    2 P 10:117:00000 00:000:00000 P - 
+ RINK  A    1 P 00:000:00000 10:117:00000 V - non linearity
+ RINK  A    2 P 10:117:00000 00:000:00000 V - 
+ RIOB  B    1 P 00:000:00000 13:094:57720 P - antenna change
+ RIOB  B    2 P 13:094:57720 00:000:00000 P -
+ RIOB  B    1 P 00:000:00000 00:000:00000 V -
+ RIOP  A    1 P 00:000:00000 98:216:68360 P - EQ M7.2 - near the coast of Ecuador
+ RIOP  A    2 P 98:216:68360 07:121:00000 P - antenna change
+ RIOP  A    3 P 07:121:00000 09:181:67680 P - antenna change
+ RIOP  A    4 P 09:181:67680 12:162:00000 P - non linearity
+ RIOP  A    5 P 12:162:00000 00:000:00000 P - 
+ RIOP  A    1 P 00:000:00000 98:216:68360 V - EQ M7.2 - near the coast of Ecuador
+ RIOP  A    2 P 98:216:68360 07:121:00000 V - antenna change
+ RIOP  A    3 P 07:121:00000 09:181:67680 V - antenna change
+ RIOP  A    4 P 09:181:67680 12:162:00000 V - non linearity
+ RIOP  A    5 P 12:162:00000 00:000:00000 V - 
+ ROAP  A    1 P 00:000:00000 00:000:00000 P -
+ ROAP  A    1 P 00:000:00000 00:000:00000 V -
+ ROB4  A    1 P 00:000:00000 00:000:00000 P -
+ ROB4  A    1 P 00:000:00000 00:000:00000 V -
+ ROSA  A    1 P 00:000:00000 07:337:00000 P - antenna change
+ ROSA  A    2 P 07:337:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ ROSA  A    3 P 10:058:23652 00:000:00000 P -
+ ROSA  A    1 P 00:000:00000 00:000:00000 V -
+ ROTG  A    1 P 00:000:00000 13:097:00000 P - unknown
+ ROTG  A    2 P 13:097:00000 00:000:00000 P -
+ ROTG  A    1 P 00:000:00000 00:000:00000 V -
+ ROTH  A    1 P 00:000:00000 00:000:00000 P -
+ ROTH  A    1 P 00:000:00000 00:000:00000 V -
+ RSBY  A    1 P 00:000:00000 00:000:00000 P -
+ RSBY  A    1 P 00:000:00000 00:000:00000 V -
+ RWSN  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ RWSN  A    2 P 10:058:23652 00:000:00000 P -
+ RWSN  A    1 P 00:000:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ RWSN  A    2 P 10:058:23652 00:000:00000 V -
+ SA15  A    1 P 00:000:00000 00:000:00000 P -
+ SA15  A    1 P 00:000:00000 00:000:00000 V -
+ SA22  A    1 P 00:000:00000 06:348:00000 P - non linearity
+ SA22  A    2 P 06:348:00000 00:000:00000 P - 
+ SA22  A    1 P 00:000:00000 06:348:00000 V - non linearity
+ SA22  A    2 P 06:348:00000 00:000:00000 V - 
+ SA26  A    1 P 00:000:00000 00:000:00000 P -
+ SA26  A    1 P 00:000:00000 00:000:00000 V -
+ SA45  A    1 P 00:000:00000 00:000:00000 P -
+ SA45  A    1 P 00:000:00000 00:000:00000 V -
+ SABL  A    1 P 00:000:00000 13:197:39600 P - antenna change
+ SABL  A    2 P 13:197:39600 00:000:00000 P -
+ SABL  A    1 P 00:000:00000 00:000:00000 V -
+ SACH  A    1 P 00:000:00000 00:000:00000 P -
+ SACH  A    1 P 00:000:00000 00:000:00000 V -
+ SAG1  A    1 P 00:000:00000 00:000:00000 P -
+ SAG1  A    1 P 00:000:00000 00:000:00000 V -
+ SAGA  A    1 P 00:000:00000 00:000:00000 P -
+ SAGA  A    1 P 00:000:00000 00:000:00000 V -
+ SALV  A    1 P 00:000:00000 00:000:00000 P -
+ SALV  A    1 P 00:000:00000 00:000:00000 V -
+ SAMO  A    1 P 00:000:00000 07:214:00000 P - antenna change
+ SAMO  A    2 P 07:214:00000 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ SAMO  A    3 P 09:272:64091 00:000:00000 P -
+ SAMO  A    1 P 00:000:00000 09:272:64091 V - EQ M8.1 - Samoa Islands region
+ SAMO  A    2 P 09:272:64091 00:000:00000 V -
+ SAMP  A    1 P 00:000:00000 04:361:03530 P - EQ M9.1 - off the west coast of northern Sumatra
+ SAMP  A    2 P 04:361:03530 05:087:58177 P - EQ M8.6 - northern Sumatra, Indonesia
+ SAMP  A    3 P 05:087:58177 09:273:36969 P - EQ M7.6 - southern Sumatra, Indonesia
+ SAMP  A    4 P 09:273:36969 10:096:80102 P - EQ M7.8 - northern Sumatra, Indonesia
+ SAMP  A    5 P 10:096:80102 11:301:00000 P - unknown
+ SAMP  A    6 P 11:301:00000 00:000:00000 P -
+ SAMP  A    1 P 00:000:00000 04:361:03530 V - EQ M9.1 - off the west coast of northern Sumatra
+ SAMP  A    2 P 04:361:03530 00:000:00000 V -
+ SANC  A    1 P 00:000:00000 97:111:43346 P - EQ M7.7 - Santa Cruz Islands
+ SANC  A    2 P 97:111:43346 97:319:68364 P - EQ M7.0 - Vanuatu
+ SANC  A    3 P 97:319:68364 99:330:48076 P - EQ M7.5 - Vanuatu
+ SANC  A    4 P 99:330:48076 00:278:61124 P - EQ M7.0 - Vanuatu
+ SANC  A    5 P 00:278:61124 07:213:61731 P - EQ M7.2 - Vanuatu
+ SANC  A    6 P 07:213:61731 09:014:00000 P - unknown
+ SANC  A    7 P 09:014:00000 09:280:79395 P - EQ M7.7 - Vanuatu
+ SANC  A    8 P 09:280:79395 10:147:62087 P - EQ M7.2 - Vanuatu
+ SANC  A    9 P 10:147:62087 00:000:00000 P -
+ SANC  A    1 P 00:000:00000 09:280:79395 V - EQ M7.7 - Vanuatu
+ SANC  A    2 P 09:280:79395 00:000:00000 V -
+ SAOB  B    1 P 00:000:00000 00:000:00000 P -
+ SAOB  B    1 P 00:000:00000 00:000:00000 V -
+ SARI  A    1 P 00:000:00000 00:000:00000 P -
+ SARI  A    1 P 00:000:00000 00:000:00000 V -
+ SARZ  A    1 P 00:000:00000 10:266:32400 P - antenna change
+ SARZ  A    2 P 10:266:32400 00:000:00000 P -
+ SARZ  A    1 P 00:000:00000 00:000:00000 V -
+ SASK  A    1 P 00:000:00000 13:243:00000 P - antenna change
+ SASK  A    2 P 13:243:00000 00:000:00000 P -
+ SASK  A    1 P 00:000:00000 00:000:00000 V -
+ SASS  A    1 P 00:000:00000 03:296:25200 P - antenna change
+ SASS  A    2 P 03:296:25200 04:237:43200 P - antenna change
+ SASS  A    3 P 04:237:43200 00:000:00000 P -
+ SASS  A    1 P 00:000:00000 00:000:00000 V -
+ SAV1  A    1 P 00:000:00000 00:000:00000 P -
+ SAV1  A    1 P 00:000:00000 00:000:00000 V -
+ SBOK  A    1 P 00:000:00000 00:000:00000 P -
+ SBOK  A    1 P 00:000:00000 00:000:00000 V -
+ SBRN  A    1 P 00:000:00000 05:288:00000 P - receiver change
+ SBRN  A    2 P 05:288:00000 08:238:36000 P - receiver change
+ SBRN  A    3 P 08:238:36000 09:044:00000 P - unknown
+ SBRN  A    4 P 09:044:00000 09:186:00000 P - unknown
+ SBRN  A    5 P 09:186:00000 00:000:00000 P -
+ SBRN  A    1 P 00:000:00000 00:000:00000 V -
+ SC02  A    1 P 00:000:00000 00:000:00000 P -
+ SC02  A    1 P 00:000:00000 00:000:00000 V -
+ SCCC  A    1 P 00:000:00000 07:029:52200 P - antenna change
+ SCCC  A    2 P 07:029:52200 00:000:00000 P -
+ SCCC  A    1 P 00:000:00000 00:000:00000 V -
+ SCHA  A    1 P 00:000:00000 00:000:00000 P -
+ SCHA  A    1 P 00:000:00000 00:000:00000 V -
+ SCHY  A    1 P 00:000:00000 00:000:00000 P -
+ SCHY  A    1 P 00:000:00000 00:000:00000 V -
+ SCIL  A    1 P 00:000:00000 00:000:00000 P -
+ SCIL  A    1 P 00:000:00000 00:000:00000 V -
+ SCIP  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ SCIP  A    2 P 99:289:35204 01:157:00000 P - antenna change
+ SCIP  A    3 P 01:157:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ SCIP  A    4 P 10:094:81643 00:000:00000 P -
+ SCIP  A    1 P 00:000:00000 00:000:00000 V -
+ SCOA  A    1 P 00:000:00000 08:344:00000 P - unknown
+ SCOA  A    2 P 08:344:00000 09:251:43200 P - antenna change
+ SCOA  A    3 P 09:251:43200 00:000:00000 P -
+ SCOA  A    1 P 00:000:00000 00:000:00000 V -
+ SEAT  A    1 P 00:000:00000 97:032:00000 P - antenna change
+ SEAT  A    2 P 97:032:00000 98:260:00000 P - antenna change
+ SEAT  A    3 P 98:260:00000 01:059:68073 P - EQ M6.8 - Puget Sound region, Washington
+ SEAT  A    4 P 01:059:68073 00:000:00000 P -
+ SEAT  A    1 P 00:000:00000 00:000:00000 V -
+ SELE  A    1 P 00:000:00000 98:343:00000 P - antenna change
+ SELE  A    2 P 98:343:00000 02:143:00000 P - unknown
+ SELE  A    3 P 02:143:00000 00:000:00000 P - 
+ SELE  A    1 P 00:000:00000 00:000:00000 V - 
+ SETE  A    1 P 00:000:00000 12:039:00000 P - unknown
+ SETE  A    2 P 12:039:00000 00:000:00000 P -
+ SETE  A    1 P 00:000:00000 00:000:00000 V -
+ SEY1  A    1 P 00:000:00000 96:032:00000 P - antenna change
+ SEY1  A    2 P 96:032:00000 98:225:00000 P - antenna change
+ SEY1  A    3 P 98:225:00000 03:037:00000 P - antenna change
+ SEY1  A    4 P 03:037:00000 07:180:00000 P - antenna change
+ SEY1  A    5 P 07:180:00000 11:215:00000 P - antenna change
+ SEY1  A    6 P 11:215:00000 00:000:00000 P -
+ SEY1  A    1 P 00:000:00000 00:000:00000 V -
+ SG02  A    1 P 00:000:00000 00:000:00000 P -
+ SG02  A    1 P 00:000:00000 00:000:00000 V -
+ SG06  A    1 P 00:000:00000 00:000:00000 P -
+ SG06  A    1 P 00:000:00000 00:000:00000 V -
+ SG21  A    1 P 00:000:00000 04:136:00000 P - unknown
+ SG21  A    2 P 04:136:00000 00:000:00000 P -
+ SG21  A    1 P 00:000:00000 00:000:00000 V -
+ SG26  A    1 P 00:000:00000 00:000:00000 P -
+ SG26  A    1 P 00:000:00000 00:000:00000 V -
+ SG40  A    1 P 00:000:00000 00:000:00000 P -
+ SG40  A    1 P 00:000:00000 00:000:00000 V -
+ SGOC  A    1 P 00:000:00000 00:000:00000 P -
+ SGOC  A    1 P 00:000:00000 00:000:00000 V -
+ SHAS  A    1 P 00:000:00000 98:230:00000 P - unknown
+ SHAS  A    2 P 98:230:00000 00:000:00000 P -
+ SHAS  A    1 P 00:000:00000 00:000:00000 V -
+ SHE2  A    1 P 00:000:00000 10:177:10800 P - antenna change
+ SHE2  A    2 P 10:177:10800 12:278:50400 P - antenna change
+ SHE2  A    3 P 12:278:50400 00:000:00000 P -
+ SHE2  A    1 P 00:000:00000 00:000:00000 V -
+ SHEE  A    1 P 00:000:00000 02:348:00000 P - non linearity
+ SHEE  A    2 P 02:348:00000 10:355:00000 P - unknown
+ SHEE  A    3 P 10:355:00000 12:037:00000 P - unknown
+ SHEE  A    4 P 12:037:00000 13:016:00000 P - unknown
+ SHEE  A    5 P 13:016:00000 00:000:00000 P - 
+ SHEE  A    1 P 00:000:00000 02:348:00000 V - non linearity
+ SHEE  A    2 P 02:348:00000 00:000:00000 V - 
+ SHK1  A    1 P 00:000:00000 95:181:00000 P - antenna change
+ SHK1  A    2 P 95:181:00000 99:075:00000 P - non linearity
+ SHK1  A    3 P 99:075:00000 04:257:00000 P - non linearity
+ SHK1  A    4 P 04:257:00000 06:122:00000 P - unknown
+ SHK1  A    5 P 06:122:00000 00:000:00000 P - 
+ SHK1  A    1 P 00:000:00000 99:075:00000 V - non linearity
+ SHK1  A    2 P 99:075:00000 04:257:00000 V - non linearity
+ SHK1  A    3 P 04:257:00000 00:000:00000 V - 
+ SHK5  A    1 P 00:000:00000 11:278:00000 P - receiver change
+ SHK5  A    2 P 11:278:00000 12:053:00000 P - unknown
+ SHK5  A    3 P 12:053:00000 00:000:00000 P -
+ SHK5  A    1 P 00:000:00000 00:000:00000 V -
+ SHOE  A    1 P 00:000:00000 07:145:36000 P - antenna change
+ SHOE  A    2 P 07:145:36000 00:000:00000 P -
+ SHOE  A    1 P 00:000:00000 00:000:00000 V -
+ SIMO  A    1 P 00:000:00000 14:280:00000 P - unknown
+ SIMO  A    2 P 14:280:00000 00:000:00000 P -
+ SIMO  A    1 P 00:000:00000 00:000:00000 V -
+ SIO3  A    1 P 00:000:00000 94:138:00000 P - antenna change
+ SIO3  A    2 P 94:138:00000 94:148:00000 P - antenna change
+ SIO3  A    3 P 94:148:00000 94:259:00000 P - receiver change
+ SIO3  A    4 P 94:259:00000 95:207:00000 P - antenna change
+ SIO3  A    5 P 95:207:00000 96:355:00000 P - non linearity
+ SIO3  A    6 P 96:355:00000 98:013:00000 P - receiver change
+ SIO3  A    7 P 98:013:00000 99:289:35204 P - EQ M7.1 - Southern California
+ SIO3  A    8 P 99:289:35204 00:103:06600 P - antenna change
+ SIO3  A    9 P 00:103:06600 05:070:00000 P - non linearity
+ SIO3  A   10 P 05:070:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ SIO3  A   11 P 10:094:81643 00:000:00000 P - 
+ SIO3  A    1 P 00:000:00000 96:355:00000 V - non linearity
+ SIO3  A    2 P 96:355:00000 05:070:00000 V - non linearity
+ SIO3  A    3 P 05:070:00000 10:094:81643 V - EQ M7.2 - Baja California, Mexico
+ SIO3  A    4 P 10:094:81643 00:000:00000 V - 
+ SIO5  A    1 P 00:000:00000 04:273:00000 P - antenna change
+ SIO5  A    2 P 04:273:00000 05:013:00000 P - antenna change
+ SIO5  A    3 P 05:013:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ SIO5  A    4 P 10:094:81643 00:000:00000 P - 
+ SIO5  A    1 P 00:000:00000 05:013:00000 V - antenna change
+ SIO5  A    2 P 05:013:00000 10:094:81643 V - EQ M7.2 - Baja California, Mexico
+ SIO5  A    3 P 10:094:81643 00:000:00000 V - 
+ SJDV  A    1 P 00:000:00000 99:071:57600 P - antenna change
+ SJDV  A    2 P 99:071:57600 00:000:00000 P -
+ SJDV  A    1 P 00:000:00000 00:000:00000 V -
+ SKE0  A    1 P 00:000:00000 07:163:00000 P - antenna change
+ SKE0  A    2 P 07:163:00000 12:180:00000 P - unknown
+ SKE0  A    3 P 12:180:00000 12:327:28200 P - antenna change
+ SKE0  A    4 P 12:327:28200 00:000:00000 P -
+ SKE0  A    1 P 00:000:00000 00:000:00000 V -
+ SLCR  A    1 P 00:000:00000 00:000:00000 P -
+ SLCR  A    1 P 00:000:00000 00:000:00000 V -
+ SLEU  A    1 P 00:000:00000 08:087:00000 P - antenna change
+ SLEU  A    2 P 08:087:00000 00:000:00000 P -
+ SLEU  A    1 P 00:000:00000 00:000:00000 V -
+ SMST  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ SMST  A    2 P 11:070:20783 12:076:21600 P - antenna change
+ SMST  A    3 P 12:076:21600 00:000:00000 P -
+ SMST  A    1 P 00:000:00000 00:000:00000 V -
+ SMTG  A    1 P 00:000:00000 00:000:00000 P -
+ SMTG  A    1 P 00:000:00000 00:000:00000 V -
+ SNFD  A    1 P 00:000:00000 13:022:73200 P - antenna change
+ SNFD  A    2 P 13:022:73200 00:000:00000 P -
+ SNFD  A    1 P 00:000:00000 00:000:00000 V -
+ SNI1  A    1 P 00:000:00000 96:192:00000 P - receiver change
+ SNI1  A    2 P 96:192:00000 98:230:00000 P - antenna change
+ SNI1  A    3 P 98:230:00000 00:354:00000 P - antenna change
+ SNI1  A    4 P 00:354:00000 11:025:70380 P - receiver change
+ SNI1  A    5 P 11:025:70380 00:000:00000 P -
+ SNI1  A    1 P 00:000:00000 00:000:00000 V -
+ SOL1  A    1 P 00:000:00000 00:000:00000 P -
+ SOL1  A    1 P 00:000:00000 00:000:00000 V -
+ SOLA  A    1 P 00:000:00000 04:139:43200 P - antenna change
+ SOLA  A    2 P 04:139:43200 00:000:00000 P -
+ SOLA  A    1 P 00:000:00000 00:000:00000 V -
+ SOUF  A    1 P 00:000:00000 09:232:00000 P - unknown
+ SOUF  A    2 P 09:232:00000 13:159:00000 P - unknown
+ SOUF  A    3 P 13:159:00000 00:000:00000 P -
+ SOUF  A    1 P 00:000:00000 00:000:00000 V -
+ SPBY  A    1 P 00:000:00000 11:326:00000 P - unknown
+ SPBY  A    2 P 11:326:00000 00:000:00000 P -
+ SPBY  A    1 P 00:000:00000 00:000:00000 V -
+ SPK1  A    1 P 00:000:00000 12:133:00000 P - receiver change
+ SPK1  A    2 P 12:133:00000 00:000:00000 P -
+ SPK1  A    1 P 00:000:00000 00:000:00000 V -
+ SPLT  A    1 P 00:000:00000 06:055:00000 P - unknown
+ SPLT  A    2 P 06:055:00000 00:000:00000 P -
+ SPLT  A    1 P 00:000:00000 00:000:00000 V -
+ SPMX  A    1 P 00:000:00000 00:000:00000 P -
+ SPMX  A    1 P 00:000:00000 00:000:00000 V -
+ SPT0  A    1 P 00:000:00000 07:160:00000 P - unknown
+ SPT0  A    2 P 07:160:00000 00:000:00000 P -
+ SPT0  A    1 P 00:000:00000 00:000:00000 V -
+ SRMP  A    1 P 00:000:00000 10:113:00000 P - non linearity
+ SRMP  A    2 P 10:113:00000 00:000:00000 P - 
+ SRMP  A    1 P 00:000:00000 10:113:00000 V - non linearity
+ SRMP  A    2 P 10:113:00000 00:000:00000 V - 
+ SRS1  A    1 P 00:000:00000 01:129:00000 P - receiver change
+ SRS1  A    2 P 01:129:00000 00:000:00000 P -
+ SRS1  A    1 P 00:000:00000 00:000:00000 V -
+ SSA1  A    1 P 00:000:00000 12:285:43200 P - antenna change
+ SSA1  A    2 P 12:285:43200 00:000:00000 P -
+ SSA1  A    1 P 00:000:00000 00:000:00000 V -
+ SSIA  A    1 P 00:000:00000 01:013:63212 P - EQ M7.7 - offshore El Salvador
+ SSIA  A    2 P 01:013:63212 01:044:51726 P - EQ M6.6 - El Salvador
+ SSIA  A    3 P 01:044:51726 09:148:30285 P - EQ M7.3 - offshore Honduras
+ SSIA  A    4 P 09:148:30285 12:065:63120 P - receiver change
+ SSIA  A    5 P 12:065:63120 12:240:16639 P - EQ M7.3 - off the coast of El Salvador
+ SSIA  A    6 P 12:240:16639 00:000:00000 P -
+ SSIA  A    1 P 00:000:00000 00:000:00000 V -
+ STAS  A    1 P 00:000:00000 07:122:53880 P - antenna change
+ STAS  A    2 P 07:122:53880 07:184:46620 P - antenna change
+ STAS  A    3 P 07:184:46620 00:000:00000 P -
+ STAS  A    1 P 00:000:00000 00:000:00000 V -
+ STJ2  A    1 P 00:000:00000 00:000:00000 P -
+ STJ2  A    1 P 00:000:00000 00:000:00000 V -
+ STK2  A    1 P 00:000:00000 03:268:71406 P - EQ M8.3 - Hokkaido, Japan region
+ STK2  A    2 P 03:268:71406 06:319:40458 P - EQ M8.3 - Kuril Islands
+ STK2  A    3 P 06:319:40458 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ STK2  A    4 P 11:070:20783 00:000:00000 P -
+ STK2  A    1 P 00:000:00000 00:000:00000 V -
+ STL3  A    1 P 00:000:00000 00:000:00000 P -
+ STL3  A    1 P 00:000:00000 00:000:00000 V -
+ STNY  A    1 P 00:000:00000 00:000:00000 P -
+ STNY  A    1 P 00:000:00000 00:000:00000 V -
+ STP1  A    1 P 00:000:00000 00:000:00000 P -
+ STP1  A    1 P 00:000:00000 00:000:00000 V -
+ STR1  A    1 P 00:000:00000 98:166:00000 P - antenna change
+ STR1  A    2 P 98:166:00000 98:268:00000 P - antenna change
+ STR1  A    3 P 98:268:00000 99:019:07260 P - antenna change
+ STR1  A    4 P 99:019:07260 99:174:10800 P - antenna change
+ STR1  A    5 P 99:174:10800 03:311:00000 P - antenna change
+ STR1  A    6 P 03:311:00000 00:000:00000 P -
+ STR1  A    1 P 00:000:00000 00:000:00000 V -
+ STR2  A    1 P 00:000:00000 03:335:00000 P - antenna change
+ STR2  A    2 P 03:335:00000 11:342:00000 P - antenna change
+ STR2  A    3 P 11:342:00000 17:333:00000 P -
+ STR2  A    4 P 17:333:00000 00:000:00000 P -
+ STR2  A    1 P 00:000:00000 00:000:00000 V -
+ STVI  A    1 P 00:000:00000 12:172:00000 P - unknown
+ STVI  A    2 P 12:172:00000 00:000:00000 P -
+ STVI  A    1 P 00:000:00000 00:000:00000 V -
+ SULP  A    1 P 00:000:00000 01:286:34680 P - antenna change
+ SULP  A    2 P 01:286:34680 13:089:40560 P - antenna change
+ SULP  A    3 P 13:089:40560 00:000:00000 P -
+ SULP  A    1 P 00:000:00000 00:000:00000 V -
+ SUMK  A    1 P 00:000:00000 00:265:00000 P - antenna change
+ SUMK  A    2 P 00:265:00000 11:177:00000 P - unknown
+ SUMK  A    3 P 11:177:00000 13:253:00000 P - unknown
+ SUMK  A    4 P 13:253:00000 00:000:00000 P -
+ SUMK  A    1 P 00:000:00000 00:000:00000 V -
+ SUNM  A    1 P 00:000:00000 00:000:00000 P -
+ SUNM  A    1 P 00:000:00000 00:000:00000 V -
+ SUTV  A    1 P 00:000:00000 00:000:00000 P -
+ SUTV  A    1 P 00:000:00000 00:000:00000 V -
+ SVTL  A    1 P 00:000:00000 97:150:00000 P - receiver change
+ SVTL  A    2 P 97:150:00000 04:336:43200 P - antenna change
+ SVTL  A    3 P 04:336:43200 08:297:36000 P - antenna change
+ SVTL  A    4 P 08:297:36000 00:000:00000 P -
+ SVTL  A    1 P 00:000:00000 00:000:00000 V -
+ SWAS  A    1 P 00:000:00000 00:000:00000 P -
+ SWAS  A    1 P 00:000:00000 00:000:00000 V -
+ SWTG  A    1 P 00:000:00000 13:316:00000 P - antenna change
+ SWTG  A    2 P 13:316:00000 00:000:00000 P -
+ SWTG  A    1 P 00:000:00000 00:000:00000 V -
+ TABL  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ TABL  A    2 P 99:289:35204 12:048:72360 P - antenna change
+ TABL  A    3 P 12:048:72360 12:133:00000 P - receiver change
+ TABL  A    4 P 12:133:00000 13:247:72900 P - antenna change
+ TABL  A    5 P 13:247:72900 13:325:74700 P - antenna change
+ TABL  A    6 P 13:325:74700 00:000:00000 P -
+ TABL  A    1 P 00:000:00000 00:000:00000 V -
+ TABV  A    1 P 00:000:00000 12:048:00000 P - antenna change
+ TABV  A    2 P 12:048:00000 13:325:00000 P - antenna change
+ TABV  A    3 P 13:325:00000 00:000:00000 P -
+ TABV  A    1 P 00:000:00000 00:000:00000 V -
+ TAH2  A    1 P 00:000:00000 00:000:00000 P -
+ TAH2  A    1 P 00:000:00000 00:000:00000 V -
+ TAIW  A    1 P 00:000:00000 94:156:04171 P - EQ M6.4 - Taiwan
+ TAIW  A    2 P 94:156:04171 94:192:00000 P - unknown
+ TAIW  A    3 P 94:192:00000 95:017:00000 P - unknown
+ TAIW  A    4 P 95:017:00000 00:000:00000 P -
+ TAIW  A    1 P 00:000:00000 00:000:00000 V -
+ TAKL  A    1 P 00:000:00000 00:000:00000 P -
+ TAKL  A    1 P 00:000:00000 00:000:00000 V -
+ TALA  A    1 P 00:000:00000 99:099:00000 P - unknown
+ TALA  A    2 P 99:099:00000 13:125:00000 P - unknown
+ TALA  A    3 P 13:125:00000 00:000:00000 P -
+ TALA  A    1 P 00:000:00000 00:000:00000 V -
+ TAMA  A    1 P 00:000:00000 00:000:00000 P -
+ TAMA  A    1 P 00:000:00000 00:000:00000 V -
+ TAMP  A    1 P 00:000:00000 00:000:00000 P -
+ TAMP  A    1 P 00:000:00000 00:000:00000 V -
+ TANZ  A    1 P 00:000:00000 07:051:00000 P - antenna change
+ TANZ  A    2 P 07:051:00000 11:197:39360 P - antenna change
+ TANZ  A    3 P 11:197:39360 13:048:00000 P - receiver change
+ TANZ  A    4 P 13:048:00000 00:000:00000 P -
+ TANZ  A    1 P 00:000:00000 00:000:00000 V -
+ TARI  A    1 P 00:000:00000 00:000:00000 P -
+ TARI  A    1 P 00:000:00000 00:000:00000 V -
+ TBTG  A    1 P 00:000:00000 00:000:00000 P -
+ TBTG  A    1 P 00:000:00000 00:000:00000 V -
+ TELA  A    1 P 00:000:00000 03:129:00000 P - unknown
+ TELA  A    2 P 03:129:00000 04:075:00000 P - antenna change
+ TELA  A    3 P 04:075:00000 09:034:00000 P - unknown
+ TELA  A    4 P 09:034:00000 00:000:00000 P -
+ TELA  A    1 P 00:000:00000 00:000:00000 V -
+ TERC  A    1 P 00:000:00000 00:000:00000 P -
+ TERC  A    1 P 00:000:00000 00:000:00000 V -
+ TERS  A    1 P 00:000:00000 99:283:00000 P - unknown
+ TERS  A    2 P 99:283:00000 00:118:39000 P - antenna change
+ TERS  A    3 P 00:118:39000 00:000:00000 P -
+ TERS  A    1 P 00:000:00000 00:000:00000 V -
+ TETN  A    1 P 00:000:00000 04:284:00000 P - unknown
+ TETN  A    2 P 04:284:00000 06:049:00000 P - unknown
+ TETN  A    3 P 06:049:00000 00:000:00000 P -
+ TETN  A    1 P 00:000:00000 00:000:00000 V -
+ TFNO  A    1 P 00:000:00000 08:296:01320 P - antenna change
+ TFNO  A    2 P 08:296:01320 11:153:00000 P - unknown
+ TFNO  A    3 P 11:153:00000 11:252:70894 P - EQ M6.4 - Vancouver Island, Canada region
+ TFNO  A    4 P 11:252:70894 00:000:00000 P -
+ TFNO  A    1 P 00:000:00000 00:000:00000 V -
+ TGBF  A    1 P 00:000:00000 00:000:00000 P -
+ TGBF  A    1 P 00:000:00000 00:000:00000 V -
+ TGBU  A    1 P 00:000:00000 00:000:00000 P -
+ TGBU  A    1 P 00:000:00000 00:000:00000 V -
+ TGDA  A    1 P 00:000:00000 00:000:00000 P -
+ TGDA  A    1 P 00:000:00000 00:000:00000 V -
+ TGDE  A    1 P 00:000:00000 00:000:00000 P -
+ TGDE  A    1 P 00:000:00000 00:000:00000 V -
+ TGEM  A    1 P 00:000:00000 00:000:00000 P -
+ TGEM  A    1 P 00:000:00000 00:000:00000 V -
+ TGKN  A    1 P 00:000:00000 10:342:43200 P - antenna change
+ TGKN  A    2 P 10:342:43200 12:060:00000 P - unknown
+ TGKN  A    3 P 12:060:00000 00:000:00000 P -
+ TGKN  A    1 P 00:000:00000 00:000:00000 V -
+ TGME  A    1 P 00:000:00000 00:000:00000 P -
+ TGME  A    1 P 00:000:00000 00:000:00000 V -
+ TGRC  A    1 P 00:000:00000 03:278:00000 P - unknown
+ TGRC  A    2 P 03:278:00000 10:001:00000 P - unknown
+ TGRC  A    3 P 10:001:00000 00:000:00000 P -
+ TGRC  A    1 P 00:000:00000 00:000:00000 V -
+ THU1  A    1 P 00:000:00000 01:257:00000 P - unknown
+ THU1  A    2 P 01:257:00000 00:000:00000 P -
+ THU1  A    1 P 00:000:00000 00:000:00000 V -
+ TIBB  A    1 P 00:000:00000 98:136:00000 P - unknown
+ TIBB  A    2 P 98:136:00000 99:273:65520 P - antenna change
+ TIBB  A    3 P 99:273:65520 14:236:37244 P - EQ M6.02 - 6km NW of American Canyon, California
+ TIBB  A    4 P 14:236:37244 00:000:00000 P - 
+ TIBB  A    1 P 00:000:00000 98:136:00000 V - unknown
+ TIBB  A    2 P 98:136:00000 00:000:00000 V - 
+ TID2  A    1 P 00:000:00000 96:178:00000 P - antenna change
+ TID2  A    2 P 96:178:00000 04:347:00000 P - antenna change
+ TID2  A    3 P 04:347:00000 09:356:00000 P - receiver change
+ TID2  A    4 P 09:356:00000 00:000:00000 P -
+ TID2  A    1 P 00:000:00000 00:000:00000 V -
+ TIMM  A    1 P 00:000:00000 12:236:00000 P - unknown
+ TIMM  A    2 P 12:236:00000 00:000:00000 P -
+ TIMM  A    1 P 00:000:00000 00:000:00000 V -
+ TITZ  A    1 P 00:000:00000 03:014:36000 P - antenna change
+ TITZ  A    2 P 03:014:36000 08:051:55800 P - antenna change
+ TITZ  A    3 P 08:051:55800 11:068:61200 P - antenna change
+ TITZ  A    4 P 11:068:61200 00:000:00000 P -
+ TITZ  A    1 P 00:000:00000 00:000:00000 V -
+ TIXG  A    1 P 00:000:00000 00:000:00000 P -
+ TIXG  A    1 P 00:000:00000 00:000:00000 V -
+ TIXJ  A    1 P 00:000:00000 08:124:00000 P - unknown
+ TIXJ  A    2 P 08:124:00000 00:000:00000 P -
+ TIXJ  A    1 P 00:000:00000 00:000:00000 V -
+ TMGO  A    1 P 00:000:00000 95:108:00000 P - antenna change
+ TMGO  A    2 P 95:108:00000 95:277:00000 P - antenna change
+ TMGO  A    3 P 95:277:00000 00:000:00000 P -
+ TMGO  A    1 P 00:000:00000 00:000:00000 V -
+ TN01  A    1 P 00:000:00000 07:198:00000 P - unknown
+ TN01  A    2 P 07:198:00000 07:256:00000 P - unknown
+ TN01  A    3 P 07:256:00000 00:000:00000 P -
+ TN01  A    1 P 00:000:00000 00:000:00000 V -
+ TN22  A    1 P 00:000:00000 00:000:00000 P -
+ TN22  A    1 P 00:000:00000 00:000:00000 V -
+ TOLF  A    1 P 00:000:00000 00:000:00000 P -
+ TOLF  A    1 P 00:000:00000 00:000:00000 V -
+ TONG  A    1 P 00:000:00000 02:352:00000 P - antenna change
+ TONG  A    2 P 02:352:00000 06:123:55600 P - EQ M8.0 - Tonga
+ TONG  A    3 P 06:123:55600 07:343:26901 P - EQ M7.8 - south of the Fiji Islands
+ TONG  A    4 P 07:343:26901 08:293:18634 P - EQ M6.9 - Tonga
+ TONG  A    5 P 08:293:18634 09:078:65861 P - EQ M7.6 - Tonga region
+ TONG  A    6 P 09:078:65861 09:272:64091 P - EQ M8.1 - Samoa Islands region
+ TONG  A    7 P 09:272:64091 11:250:00000 P - antenna change
+ TONG  A    8 P 11:250:00000 00:000:00000 P -
+ TONG  A    1 P 00:000:00000 00:000:00000 V -
+ TOPL  A    1 P 00:000:00000 13:268:67920 P - antenna change
+ TOPL  A    2 P 13:268:67920 14:269:55800 P - receiver change
+ TOPL  A    3 P 14:269:55800 00:000:00000 P -
+ TOPL  A    1 P 00:000:00000 00:000:00000 V -
+ TORI  A    1 P 00:000:00000 98:194:00000 P - antenna change
+ TORI  A    2 P 98:194:00000 00:000:00000 P -
+ TORI  A    1 P 00:000:00000 00:000:00000 V -
+ TORP  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ TORP  A    2 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ TORP  A    3 P 10:094:81643 11:007:85500 P - antenna change
+ TORP  A    4 P 11:007:85500 13:154:84720 P - receiver change
+ TORP  A    5 P 13:154:84720 00:000:00000 P -
+ TORP  A    1 P 00:000:00000 00:000:00000 V -
+ TORS  A    1 P 00:000:00000 02:085:00000 P - antenna change
+ TORS  A    2 P 02:085:00000 00:000:00000 P -
+ TORS  A    1 P 00:000:00000 00:000:00000 V -
+ TRAK  A    1 P 00:000:00000 94:315:00000 P - antenna change
+ TRAK  A    2 P 94:315:00000 95:216:00000 P - antenna change
+ TRAK  A    3 P 95:216:00000 99:289:35204 P - EQ M7.1 - Southern California
+ TRAK  A    4 P 99:289:35204 09:091:00000 P - antenna change
+ TRAK  A    5 P 09:091:00000 00:000:00000 P - 
+ TRAK  A    1 P 00:000:00000 00:000:00000 V - 
+ TRDS  A    1 P 00:000:00000 07:127:58020 P - antenna change
+ TRDS  A    2 P 07:127:58020 00:000:00000 P -
+ TRDS  A    1 P 00:000:00000 00:000:00000 V -
+ TREO  A    1 P 00:000:00000 09:347:00000 P - non linearity
+ TREO  A    2 P 09:347:00000 00:000:00000 P - 
+ TREO  A    1 P 00:000:00000 09:347:00000 V - non linearity
+ TREO  A    2 P 09:347:00000 00:000:00000 V - 
+ TRIE  A    1 P 00:000:00000 00:000:00000 P -
+ TRIE  A    1 P 00:000:00000 00:000:00000 V -
+ TSK2  A    1 P 00:000:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ TSK2  A    2 P 04:249:53839 05:292:42283 P - EQ M6.3 - near the east coast of Honshu, Japan
+ TSK2  A    3 P 05:292:42283 08:128:60320 P - EQ M6.9 - near the east coast of Honshu, Japan
+ TSK2  A    4 P 08:128:60320 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ TSK2  A    5 P 11:070:20783 11:182:02940 P - antenna change
+ TSK2  A    6 P 11:182:02940 11:242:05220 P - antenna change
+ TSK2  A    7 P 11:242:05220 00:000:00000 P -
+ TSK2  A    1 P 00:000:00000 00:000:00000 V -
+ TSKB  A    1 P 00:000:00000 94:277:48178 P - EQ M8.3 - Kuril Islands
+ TSKB  A    2 P 94:277:48178 00:235:33600 P - antenna change
+ TSKB  A    3 P 00:235:33600 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ TSKB  A    4 P 04:249:53839 05:292:42283 P - EQ M6.3 - near the east coast of Honshu, Japan
+ TSKB  A    5 P 05:292:42283 08:128:60320 P - EQ M6.9 - near the east coast of Honshu, Japan
+ TSKB  A    6 P 08:128:60320 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ TSKB  A    7 P 11:070:20783 11:182:02940 P - antenna change
+ TSKB  A    8 P 11:182:02940 11:242:05220 P - antenna change
+ TSKB  A    9 P 11:242:05220 12:327:00000 P - unknown mjia
+ TSKB  A   10 P 12:327:00000 00:000:00000 P -
+ TSKB  A    1 P 00:000:00000 00:000:00000 V -
+ TUBI  A    1 P 00:000:00000 99:007:00000 P - antenna change
+ TUBI  A    2 P 99:007:00000 99:229:00099 P - EQ M7.6 - western Turkey
+ TUBI  A    3 P 99:229:00099 99:316:61040 P - EQ M7.2 - western Turkey
+ TUBI  A    4 P 99:316:61040 00:000:00000 P -
+ TUBI  A    1 P 00:000:00000 00:000:00000 V -
+ TUC2  A    1 P 00:000:00000 04:288:36000 P - antenna change
+ TUC2  A    2 P 04:288:36000 10:196:33000 P - antenna change
+ TUC2  A    3 P 10:196:33000 00:000:00000 P -
+ TUC2  A    1 P 00:000:00000 00:000:00000 V -
+ TUCU  A    1 P 00:000:00000 06:244:00000 P - receiver change
+ TUCU  A    2 P 06:244:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ TUCU  A    3 P 10:058:23652 00:000:00000 P -
+ TUCU  A    1 P 00:000:00000 00:000:00000 V -
+ TUKT  A    1 P 00:000:00000 03:313:00000 P - unknown
+ TUKT  A    2 P 03:313:00000 12:258:00000 P - unknown
+ TUKT  A    3 P 12:258:00000 00:000:00000 P -
+ TUKT  A    1 P 00:000:00000 00:000:00000 V -
+ TXGA  A    1 P 00:000:00000 11:164:00000 P - antenna change
+ TXGA  A    2 P 11:164:00000 00:000:00000 P -
+ TXGA  A    1 P 00:000:00000 00:000:00000 V -
+ TXGV  A    1 P 00:000:00000 00:000:00000 P -
+ TXGV  A    1 P 00:000:00000 00:000:00000 V -
+ UCLP  A    1 P 00:000:00000 95:007:00000 P - unknown
+ UCLP  A    2 P 95:007:00000 95:054:00000 P - antenna change
+ UCLP  A    3 P 95:054:00000 00:297:00000 P - receiver change
+ UCLP  A    4 P 00:297:00000 12:265:71760 P - antenna change
+ UCLP  A    5 P 12:265:71760 00:000:00000 P -
+ UCLP  A    1 P 00:000:00000 00:000:00000 V -
+ UCLU  A    1 P 00:000:00000 95:223:59400 P - antenna change
+ UCLU  A    2 P 95:223:59400 00:153:82800 P - antenna change
+ UCLU  A    3 P 00:153:82800 01:339:71100 P - antenna change
+ UCLU  A    4 P 01:339:71100 07:026:00000 P - receiver change
+ UCLU  A    5 P 07:026:00000 00:000:00000 P -
+ UCLU  A    1 P 00:000:00000 00:000:00000 V -
+ UCNF  A    1 P 00:000:00000 05:164:81874 P - EQ M7.8 - Tarapaca, Chile
+ UCNF  A    2 P 05:164:81874 07:318:56451 P - EQ M7.7 - Antofagasta, Chile
+ UCNF  A    3 P 07:318:56451 08:015:00000 P - unknown
+ UCNF  A    4 P 08:015:00000 00:000:00000 P -
+ UCNF  A    1 P 00:000:00000 00:000:00000 V -
+ UCOM  A    1 P 00:000:00000 11:195:00000 P - unknown
+ UCOM  A    2 P 11:195:00000 00:000:00000 P -
+ UCOM  A    1 P 00:000:00000 00:000:00000 V -
+ UCSF  A    1 P 00:000:00000 11:266:84300 P - antenna change
+ UCSF  A    2 P 11:266:84300 12:325:75600 P - receiver change
+ UCSF  A    3 P 12:325:75600 00:000:00000 P -
+ UCSF  A    1 P 00:000:00000 00:000:00000 V -
+ UEPP  A    1 P 00:000:00000 00:000:00000 P -
+ UEPP  A    1 P 00:000:00000 00:000:00000 V -
+ ULAB  A    1 P 00:000:00000 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ ULAB  A    2 P 11:070:20783 11:263:00000 P - antenna change
+ ULAB  A    3 P 11:263:00000 12:314:00000 P - unknown
+ ULAB  A    4 P 12:314:00000 13:008:45480 P - receiver change
+ ULAB  A    5 P 13:008:45480 00:000:00000 P -
+ ULAB  A    1 P 00:000:00000 00:000:00000 V -
+ ULDI  A    1 P 00:000:00000 00:000:00000 P -
+ ULDI  A    1 P 00:000:00000 00:000:00000 V -
+ ULLA  A    1 P 00:000:00000 09:034:00000 P - unknown
+ ULLA  A    2 P 09:034:00000 15:272:00000 P -
+ ULLA  A    3 P 15:272:00000 18:234:00000 P -
+ ULLA  A    4 P 18:234:00000 00:000:00000 P -
+ ULLA  A    1 P 00:000:00000 00:000:00000 V -
+ UMSS  A    1 P 00:000:00000 07:255:40227 P - EQ M8.5 - southern Sumatra, Indonesia
+ UMSS  A    2 P 07:255:40227 10:204:82272 P - EQ M7.6 - Moro Gulf, Mindanao, Philippines
+ UMSS  A    3 P 10:204:82272 11:113:00000 P - non linearity
+ UMSS  A    4 P 11:113:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ UMSS  A    5 P 12:102:31117 00:000:00000 P - 
+ UMSS  A    1 P 00:000:00000 11:113:00000 V - non linearity
+ UMSS  A    2 P 11:113:00000 00:000:00000 V - 
+ UNB1  A    1 P 00:000:00000 06:228:00000 P - unknown
+ UNB1  A    2 P 06:228:00000 00:000:00000 P -
+ UNB1  A    1 P 00:000:00000 00:000:00000 V -
+ UNIP  A    1 P 00:000:00000 07:211:00000 P - non linearity
+ UNIP  A    2 P 07:211:00000 10:049:00000 P - non linearity
+ UNIP  A    3 P 10:049:00000 12:080:64968 P - EQ M7.4 - Oaxaca, Mexico
+ UNIP  A    4 P 12:080:64968 00:000:00000 P - 
+ UNIP  A    1 P 00:000:00000 07:211:00000 V - non linearity
+ UNIP  A    2 P 07:211:00000 10:049:00000 V - non linearity
+ UNIP  A    3 P 10:049:00000 00:000:00000 V - 
+ UNPG  A    1 P 00:000:00000 98:327:00000 P - unknown
+ UNPG  A    2 P 98:327:00000 00:039:00000 P - unknown
+ UNPG  A    3 P 00:039:00000 02:141:00000 P - unknown
+ UNPG  A    4 P 02:141:00000 02:208:00000 P - unknown
+ UNPG  A    5 P 02:208:00000 06:109:63600 P - antenna change
+ UNPG  A    6 P 06:109:63600 00:000:00000 P -
+ UNPG  A    1 P 00:000:00000 00:000:00000 V -
+ UNPM  A    1 P 00:000:00000 00:000:00000 P -
+ UNPM  A    1 P 00:000:00000 00:000:00000 V -
+ UPAD  A    1 P 00:000:00000 98:006:00000 P - unknown
+ UPAD  A    2 P 98:006:00000 00:000:00000 P -
+ UPAD  A    1 P 00:000:00000 00:000:00000 V -
+ UPO1  A    1 P 00:000:00000 06:288:62052 P - EQ M6.1 - Hawaii region, Hawaii
+ UPO1  A    2 P 06:288:62052 00:000:00000 P -
+ UPO1  A    1 P 00:000:00000 00:000:00000 V -
+ URUM  A    1 P 00:000:00000 99:267:00000 P - receiver change
+ URUM  A    2 P 99:267:00000 05:244:00000 P - receiver change
+ URUM  A    3 P 05:244:00000 07:168:00000 P - unknown
+ URUM  A    4 P 07:168:00000 08:261:00000 P - antenna change
+ URUM  A    5 P 08:261:00000 13:061:00000 P - unknown mjia
+ URUM  A    6 P 13:061:00000 00:000:00000 P -
+ URUM  A    1 P 00:000:00000 00:000:00000 V -
+ USC1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ USC1  A    2 P 99:289:35204 01:001:00000 P - unknown
+ USC1  A    3 P 01:001:00000 00:000:00000 P -
+ USC1  A    1 P 00:000:00000 99:289:35204 V - EQ M7.1 - Southern California
+ USC1  A    2 P 99:289:35204 00:000:00000 V -
+ USLO  A    1 P 00:000:00000 03:356:69356 P - EQ M6.6 - Central California
+ USLO  A    2 P 03:356:69356 04:272:62124 P - EQ M6.0 - 18km N of Shandon, California
+ USLO  A    3 P 04:272:62124 00:000:00000 P -
+ USLO  A    1 P 00:000:00000 00:000:00000 V -
+ USMX  A    1 P 00:000:00000 14:196:21780 P - antenna change
+ USMX  A    2 P 14:196:21780 00:000:00000 P -
+ USMX  A    1 P 00:000:00000 00:000:00000 V -
+ USNA  A    1 P 00:000:00000 97:268:43200 P - antenna change
+ USNA  A    2 P 97:268:43200 00:000:00000 P -
+ USNA  A    1 P 00:000:00000 00:000:00000 V -
+ USUD  A    1 P 00:000:00000 94:277:48178 P - EQ M8.3 - Kuril Islands
+ USUD  A    2 P 94:277:48178 00:279:00000 P - receiver change
+ USUD  A    3 P 00:279:00000 04:249:53839 P - EQ M7.4 - near the south coast of Honshu, Japan
+ USUD  A    4 P 04:249:53839 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ USUD  A    5 P 11:070:20783 12:327:00000 P - unknown mjia
+ USUD  A    6 P 12:327:00000 00:000:00000 P -
+ USUD  A    1 P 00:000:00000 04:249:53839 V - EQ M7.4 - near the south coast of Honshu, Japan
+ USUD  A    2 P 04:249:53839 00:000:00000 V -
+ VAAS  A    1 P 00:000:00000 00:000:00000 P -
+ VAAS  A    1 P 00:000:00000 00:000:00000 V -
+ VACO  A    1 P 00:000:00000 00:000:00000 P -
+ VACO  A    1 P 00:000:00000 00:000:00000 V -
+ VAGP  A    1 P 00:000:00000 00:000:00000 P -
+ VAGP  A    1 P 00:000:00000 00:000:00000 V -
+ VALD  A    1 P 00:000:00000 06:034:51600 P - antenna change
+ VALD  A    2 P 06:034:51600 09:199:00000 P - antenna change
+ VALD  A    3 P 09:199:00000 00:000:00000 P -
+ VALD  A    1 P 00:000:00000 00:000:00000 V -
+ VALE  A    1 P 00:000:00000 04:193:00000 P - unknown
+ VALE  A    2 P 04:193:00000 05:216:00000 P - unknown
+ VALE  A    3 P 05:216:00000 10:259:00000 P - antenna change
+ VALE  A    4 P 10:259:00000 00:000:00000 P -
+ VALE  A    1 P 00:000:00000 00:000:00000 V -
+ VALN  A    1 P 00:000:00000 05:197:00000 P - unknown
+ VALN  A    2 P 05:197:00000 10:001:00000 P - unknown
+ VALN  A    3 P 10:001:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ VALN  A    4 P 10:058:23652 10:162:00000 P - unknown
+ VALN  A    5 P 10:162:00000 11:001:00000 P - unknown
+ VALN  A    6 P 11:001:00000 12:108:13816 P - EQ M6.7 - Valparaiso, Chile
+ VALN  A    7 P 12:108:13816 00:000:00000 P -
+ VALN  A    1 P 00:000:00000 00:000:00000 V -
+ VALP  A    1 P 00:000:00000 01:099:32457 P - EQ M6.7 - off the coast of Valparaiso, Chile
+ VALP  A    2 P 01:099:32457 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ VALP  A    3 P 10:058:23652 12:108:13816 P - EQ M6.7 - Valparaiso, Chile
+ VALP  A    4 P 12:108:13816 14:235:81143 P - EQ M6.4 - 23km WNW of Hacienda La Calera, Chile
+ VALP  A    5 P 14:235:81143 00:000:00000 P -
+ VALP  A    1 P 00:000:00000 00:000:00000 V -
+ VAN1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ VAN1  A    2 P 99:289:35204 07:323:00000 P - unknown
+ VAN1  A    3 P 07:323:00000 00:000:00000 P -
+ VAN1  A    1 P 00:000:00000 00:000:00000 V -
+ VANU  A    1 P 00:000:00000 04:113:36673 P - EQ M6.0 - Vanuatu
+ VANU  A    2 P 04:113:36673 04:118:84499 P - EQ M6.0 - Vanuatu
+ VANU  A    3 P 04:118:84499 04:189:77363 P - EQ M5.8 - Vanuatu
+ VANU  A    4 P 04:189:77363 05:268:46547 P - EQ M6.1 - Vanuatu
+ VANU  A    5 P 05:268:46547 06:023:21780 P - EQ M6.4 - Vanuatu
+ VANU  A    6 P 06:023:21780 09:153:08224 P - EQ M6.3 - Vanuatu
+ VANU  A    7 P 09:153:08224 09:163:35055 P - EQ M6.0 - Vanuatu
+ VANU  A    8 P 09:163:35055 09:207:82891 P - EQ M5.8 - Vanuatu
+ VANU  A    9 P 09:207:82891 10:222:19425 P - EQ M7.3 - Vanuatu
+ VANU  A   10 P 10:222:19425 11:232:60903 P - EQ M7.2 - Vanuatu
+ VANU  A   11 P 11:232:60903 12:033:48881 P - EQ M7.1 - Vanuatu
+ VANU  A   12 P 12:033:48881 00:000:00000 P -
+ VANU  A    1 P 00:000:00000 10:222:19425 V - EQ M7.3 - Vanuatu
+ VANU  A    2 P 10:222:19425 00:000:00000 V -
+ VARS  A    1 P 00:000:00000 09:125:45480 P - antenna change
+ VARS  A    2 P 09:125:45480 10:179:60000 P - antenna change
+ VARS  A    3 P 10:179:60000 00:000:00000 P -
+ VARS  A    1 P 00:000:00000 00:000:00000 V -
+ VATU  A    1 P 00:000:00000 09:280:79395 P - EQ M7.7 - Vanuatu
+ VATU  A    2 P 09:280:79395 00:000:00000 P -
+ VATU  A    1 P 00:000:00000 00:000:00000 V -
+ VBCA  A    1 P 00:000:00000 10:058:23652 P - EQ M8.8 - offshore Bio-Bio, Chile
+ VBCA  A    2 P 10:058:23652 00:000:00000 P -
+ VBCA  A    1 P 00:000:00000 10:058:23652 V - EQ M8.8 - offshore Bio-Bio, Chile
+ VBCA  A    2 P 10:058:23652 00:000:00000 V -
+ VCIO  A    1 P 00:000:00000 00:000:00000 P -
+ VCIO  A    1 P 00:000:00000 00:000:00000 V -
+ VEN1  A    1 P 00:000:00000 00:000:00000 P -
+ VEN1  A    1 P 00:000:00000 00:000:00000 V -
+ VENE  A    1 P 00:000:00000 97:274:00000 P - antenna change
+ VENE  A    2 P 97:274:00000 99:237:00000 P - unknown
+ VENE  A    3 P 99:237:00000 01:032:36000 P - antenna change
+ VENE  A    4 P 01:032:36000 01:350:00000 P - unknown
+ VENE  A    5 P 01:350:00000 05:301:36000 P - antenna change
+ VENE  A    6 P 05:301:36000 00:000:00000 P - 
+ VENE  A    1 P 00:000:00000 00:000:00000 V - 
+ VIGO  A    1 P 00:000:00000 07:082:00000 P - receiver change
+ VIGO  A    2 P 07:082:00000 00:000:00000 P -
+ VIGO  A    1 P 00:000:00000 00:000:00000 V -
+ VIKH  A    1 P 00:000:00000 00:000:00000 P -
+ VIKH  A    1 P 00:000:00000 00:000:00000 V -
+ VIL0  A    1 P 00:000:00000 07:149:34200 P - receiver change
+ VIL0  A    2 P 07:149:34200 10:242:50400 P - antenna change
+ VIL0  A    3 P 10:242:50400 14:014:61200 P - receiver change
+ VIL0  A    4 P 14:014:61200 00:000:00000 P -
+ VIL0  A    1 P 00:000:00000 00:000:00000 V -
+ VILA  A    1 P 00:000:00000 02:002:62569 P - EQ M7.2 - Vanuatu
+ VILA  A    2 P 02:002:62569 04:113:36673 P - EQ M6.0 - Vanuatu
+ VILA  A    3 P 04:113:36673 04:118:84499 P - EQ M6.0 - Vanuatu
+ VILA  A    4 P 04:118:84499 04:189:77363 P - EQ M5.8 - Vanuatu
+ VILA  A    5 P 04:189:77363 05:268:46547 P - EQ M6.1 - Vanuatu
+ VILA  A    6 P 05:268:46547 06:023:21780 P - EQ M6.4 - Vanuatu
+ VILA  A    7 P 06:023:21780 09:153:08224 P - EQ M6.3 - Vanuatu
+ VILA  A    8 P 09:153:08224 09:163:35055 P - EQ M6.0 - Vanuatu
+ VILA  A    9 P 09:163:35055 09:207:82891 P - EQ M5.8 - Vanuatu
+ VILA  A   10 P 09:207:82891 10:222:19425 P - EQ M7.3 - Vanuatu
+ VILA  A   11 P 10:222:19425 11:232:60903 P - EQ M7.2 - Vanuatu
+ VILA  A   12 P 11:232:60903 12:033:48881 P - EQ M7.1 - Vanuatu
+ VILA  A   13 P 12:033:48881 00:000:00000 P -
+ VILA  A    1 P 00:000:00000 02:002:62569 V - EQ M7.2 - Vanuatu
+ VILA  A    2 P 02:002:62569 10:222:19425 V - EQ M7.3 - Vanuatu
+ VILA  A    3 P 10:222:19425 00:000:00000 V -
+ VILL  A    1 P 00:000:00000 95:012:00000 P - unknown
+ VILL  A    2 P 95:012:00000 99:271:00000 P - unknown
+ VILL  A    3 P 99:271:00000 01:149:00000 P - receiver change
+ VILL  A    4 P 01:149:00000 04:272:43200 P - antenna change
+ VILL  A    5 P 04:272:43200 06:333:36000 P - antenna change
+ VILL  A    6 P 06:333:36000 12:362:36900 P - antenna change
+ VILL  A    7 P 12:362:36900 00:000:00000 P - 
+ VILL  A    1 P 00:000:00000 04:272:43200 V - antenna change
+ VILL  A    2 P 04:272:43200 06:333:36000 V - antenna change
+ VILL  A    3 P 06:333:36000 00:000:00000 V - 
+ VIMS  A    1 P 00:000:00000 01:212:52380 P - antenna change
+ VIMS  A    2 P 01:212:52380 08:086:00000 P - unknown
+ VIMS  A    3 P 08:086:00000 09:260:57900 P - receiver change
+ VIMS  A    4 P 09:260:57900 11:280:00000 P - antenna change
+ VIMS  A    5 P 11:280:00000 00:000:00000 P -
+ VIMS  A    1 P 00:000:00000 00:000:00000 V -
+ VIS0  A    1 P 00:000:00000 00:000:00000 P -
+ VIS0  A    1 P 00:000:00000 00:000:00000 V -
+ VITH  A    1 P 00:000:00000 00:000:00000 P -
+ VITH  A    1 P 00:000:00000 00:000:00000 V -
+ VLIS  A    1 P 00:000:00000 00:000:00000 P -
+ VLIS  A    1 P 00:000:00000 00:000:00000 V -
+ VNAD  A    1 P 00:000:00000 00:000:00000 P -
+ VNAD  A    1 P 00:000:00000 00:000:00000 V -
+ VOIL  A    1 P 00:000:00000 00:000:00000 P -
+ VOIL  A    1 P 00:000:00000 00:000:00000 V -
+ VTIS  A    1 P 00:000:00000 99:207:00000 P - antenna change
+ VTIS  A    2 P 99:207:00000 99:289:35204 P - EQ M7.1 - Southern California
+ VTIS  A    3 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ VTIS  A    4 P 10:094:81643 12:035:03300 P - antenna change
+ VTIS  A    5 P 12:035:03300 00:000:00000 P -
+ VTIS  A    1 P 00:000:00000 00:000:00000 V -
+ VTSP  A    1 P 00:000:00000 00:000:00000 P -
+ VTSP  A    1 P 00:000:00000 00:000:00000 V -
+ WAB2  A    1 P 00:000:00000 00:000:00000 P -
+ WAB2  A    1 P 00:000:00000 00:000:00000 V -
+ WARK  A    1 P 00:000:00000 16:318:00000 P -
+ WARK  A    2 P 16:318:00000 00:000:00000 P -
+ WARK  A    1 P 00:000:00000 00:000:00000 V -
+ WARN  A    1 P 00:000:00000 03:295:28800 P - antenna change
+ WARN  A    2 P 03:295:28800 10:258:34200 P - antenna change
+ WARN  A    3 P 10:258:34200 00:000:00000 P -
+ WARN  A    1 P 00:000:00000 00:000:00000 V -
+ WDC1  A    1 P 00:000:00000 05:230:00000 P - unknown
+ WDC1  A    2 P 05:230:00000 00:000:00000 P -
+ WDC1  A    1 P 00:000:00000 00:000:00000 V -
+ WDC3  A    1 P 00:000:00000 00:000:00000 P -
+ WDC3  A    1 P 00:000:00000 00:000:00000 V -
+ WDC4  A    1 P 00:000:00000 00:000:00000 P -
+ WDC4  A    1 P 00:000:00000 00:000:00000 V -
+ WEL1  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ WEL1  A    2 P 04:358:53944 07:265:00000 P - non linearity
+ WEL1  A    3 P 07:265:00000 00:000:00000 P - 
+ WEL1  A    1 P 00:000:00000 07:265:00000 V - non linearity
+ WEL1  A    2 P 07:265:00000 00:000:00000 V - 
+ WEL2  A    1 P 00:000:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ WEL2  A    2 P 04:358:53944 07:265:00000 P - non linearity
+ WEL2  A    3 P 07:265:00000 00:000:00000 P - 
+ WEL2  A    1 P 00:000:00000 07:265:00000 V - non linearity
+ WEL2  A    2 P 07:265:00000 00:000:00000 V - 
+ WEYB  A    1 P 00:000:00000 09:070:43200 P - antenna change
+ WEYB  A    2 P 09:070:43200 00:000:00000 P -
+ WEYB  A    1 P 00:000:00000 00:000:00000 V -
+ WGTN  A    1 P 00:000:00000 99:165:00000 P - receiver change
+ WGTN  A    2 P 99:165:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ WGTN  A    3 P 04:358:53944 05:080:07200 P - antenna change
+ WGTN  A    4 P 05:080:07200 07:265:00000 P - non linearity
+ WGTN  A    5 P 07:265:00000 09:029:00000 P - non linearity
+ WGTN  A    6 P 09:029:00000 13:202:18572 P - EQ M6.5 - 46km ESE of Blenheim, New Zealand
+ WGTN  A    7 P 13:202:18572 13:228:09066 P - EQ M6.5 - 29km SE of Blenheim, New Zealand
+ WGTN  A    8 P 13:228:09066 00:000:00000 P - 
+ WGTN  A    1 P 00:000:00000 07:265:00000 V - non linearity
+ WGTN  A    2 P 07:265:00000 09:029:00000 V - non linearity
+ WGTN  A    3 P 09:029:00000 13:202:18572 V - EQ M6.5 - 46km ESE of Blenheim, New Zealand
+ WGTN  A    4 P 13:202:18572 00:000:00000 V - 
+ WGTT  A    1 P 00:000:00000 00:231:00000 P - antenna change
+ WGTT  A    2 P 00:231:00000 04:358:53944 P - EQ M8.1 - north of Macquarie Island
+ WGTT  A    3 P 04:358:53944 07:265:00000 P - non linearity
+ WGTT  A    4 P 07:265:00000 09:029:00000 P - non linearity
+ WGTT  A    5 P 09:029:00000 13:202:18572 P - EQ M6.5 - 46km ESE of Blenheim, New Zealand
+ WGTT  A    6 P 13:202:18572 13:228:09066 P - EQ M6.5 - 29km SE of Blenheim, New Zealand
+ WGTT  A    7 P 13:228:09066 00:000:00000 P - 
+ WGTT  A    1 P 00:000:00000 07:265:00000 V - non linearity
+ WGTT  A    2 P 07:265:00000 09:029:00000 V - non linearity
+ WGTT  A    3 P 09:029:00000 13:202:18572 V - EQ M6.5 - 46km ESE of Blenheim, New Zealand
+ WGTT  A    4 P 13:202:18572 00:000:00000 V - 
+ WHC1  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ WHC1  A    2 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ WHC1  A    3 P 10:094:81643 12:072:82620 P - antenna change
+ WHC1  A    4 P 12:072:82620 00:000:00000 P -
+ WHC1  A    1 P 00:000:00000 99:289:35204 V - EQ M7.1 - Southern California
+ WHC1  A    2 P 99:289:35204 00:000:00000 V -
+ WHN0  A    1 P 00:000:00000 00:000:00000 P -
+ WHN0  A    1 P 00:000:00000 00:000:00000 V -
+ WIDC  A    1 P 00:000:00000 99:289:35204 P - EQ M7.1 - Southern California
+ WIDC  A    2 P 99:289:35204 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ WIDC  A    3 P 10:094:81643 00:000:00000 P -
+ WIDC  A    1 P 00:000:00000 00:000:00000 V -
+ WINT  A    1 P 00:000:00000 96:099:00000 P - antenna change
+ WINT  A    2 P 96:099:00000 00:000:00000 P -
+ WINT  A    1 P 00:000:00000 00:000:00000 V -
+ WIS1  A    1 P 00:000:00000 00:000:00000 P -
+ WIS1  A    1 P 00:000:00000 00:000:00000 V -
+ WLAD  A    1 P 00:000:00000 00:000:00000 P -
+ WLAD  A    1 P 00:000:00000 00:000:00000 V -
+ WLPS  A    1 P 00:000:00000 00:000:00000 P -
+ WLPS  A    1 P 00:000:00000 00:000:00000 V -
+ WNFL  A    1 P 00:000:00000 98:062:00000 P - antenna change
+ WNFL  A    2 P 98:062:00000 00:000:00000 P -
+ WNFL  A    1 P 00:000:00000 00:000:00000 V -
+ WOOL  A    1 P 00:000:00000 00:000:00000 P -
+ WOOL  A    1 P 00:000:00000 00:000:00000 V -
+ WRHS  A    1 P 00:000:00000 10:094:81643 P - EQ M7.2 - Baja California, Mexico
+ WRHS  A    2 P 10:094:81643 12:276:73200 P - antenna change
+ WRHS  A    3 P 12:276:73200 00:000:00000 P -
+ WRHS  A    1 P 00:000:00000 00:000:00000 V -
+ WROC  A    1 P 00:000:00000 00:136:00000 P - antenna change
+ WROC  A    2 P 00:136:00000 06:234:00000 P - unknown
+ WROC  A    3 P 06:234:00000 07:103:54000 P - antenna change
+ WROC  A    4 P 07:103:54000 12:296:39660 P - antenna change
+ WROC  A    5 P 12:296:39660 00:000:00000 P -
+ WROC  A    1 P 00:000:00000 00:000:00000 V -
+ WSLR  A    1 P 00:000:00000 00:089:78780 P - antenna change
+ WSLR  A    2 P 00:089:78780 13:032:00000 P - unknown
+ WSLR  A    3 P 13:032:00000 00:000:00000 P -
+ WSLR  A    1 P 00:000:00000 00:000:00000 V -
+ WSMN  A    1 P 00:000:00000 00:000:00000 P -
+ WSMN  A    1 P 00:000:00000 00:000:00000 V -
+ WTZA  A    1 P 00:000:00000 00:000:00000 P -
+ WTZA  A    1 P 00:000:00000 00:000:00000 V -
+ WTZJ  A    1 P 00:000:00000 05:214:32400 P - antenna change
+ WTZJ  A    2 P 05:214:32400 09:351:27300 P - antenna change
+ WTZJ  A    3 P 09:351:27300 00:000:00000 P -
+ WTZJ  A    1 P 00:000:00000 00:000:00000 V -
+ WTZS  A    1 P 00:000:00000 06:060:00000 P - unknown
+ WTZS  A    2 P 06:060:00000 10:056:48600 P - antenna change
+ WTZS  A    3 P 10:056:48600 10:181:48600 P - antenna change
+ WTZS  A    4 P 10:181:48600 00:000:00000 P - 
+ WTZS  A    1 P 00:000:00000 00:000:00000 V - 
+ WTZT  A    1 P 00:000:00000 97:353:30600 P - antenna change
+ WTZT  A    2 P 97:353:30600 98:308:45600 P - antenna change
+ WTZT  A    3 P 98:308:45600 00:019:50400 P - antenna change
+ WTZT  A    4 P 00:019:50400 00:000:00000 P -
+ WTZT  A    1 P 00:000:00000 00:000:00000 V -
+ WTZZ  A    1 P 00:000:00000 03:161:39600 P - antenna change
+ WTZZ  A    2 P 03:161:39600 11:035:36060 P - antenna change
+ WTZZ  A    3 P 11:035:36060 00:000:00000 P -
+ WTZZ  A    1 P 00:000:00000 00:000:00000 V -
+ XCTY  A    1 P 00:000:00000 13:319:10800 P - antenna change
+ XCTY  A    2 P 13:319:10800 00:000:00000 P -
+ XCTY  A    1 P 00:000:00000 00:000:00000 V -
+ XIAN  A    1 P 00:000:00000 06:063:03600 P - antenna change
+ XIAN  A    2 P 06:063:03600 08:133:23282 P - EQ M7.9 - eastern Sichuan, China
+ XIAN  A    3 P 08:133:23282 11:070:20783 P - EQ M9.0 - near the east coast of Honshu, Japan
+ XIAN  A    4 P 11:070:20783 00:000:00000 P -
+ XIAN  A    1 P 00:000:00000 08:133:23282 V - EQ M7.9 - eastern Sichuan, China
+ XIAN  A    2 P 08:133:23282 00:000:00000 V -
+ YAR3  A    1 P 00:000:00000 08:130:00000 P - receiver change
+ YAR3  A    2 P 08:130:00000 08:340:00000 P - antenna change
+ YAR3  A    3 P 08:340:00000 12:102:31117 P - EQ M8.6 - off the west coast of northern Sumatra
+ YAR3  A    4 P 12:102:31117 00:000:00000 P -
+ YAR3  A    1 P 00:000:00000 00:000:00000 V -
+ YARR  A    1 P 00:000:00000 07:277:10800 P - antenna change
+ YARR  A    2 P 07:277:10800 14:360:00000 P - receiver change
+ YARR  A    3 P 14:360:00000 00:000:00000 P -
+ YARR  A    1 P 00:000:00000 00:000:00000 V -
+ YCBA  A    1 P 00:000:00000 14:091:85607 P - EQ M8.2 - 94km NW of Iquique, Chile
+ YCBA  A    2 P 14:091:85607 00:000:00000 P -
+ YCBA  A    1 P 00:000:00000 00:000:00000 V -
+ YEL2  A    1 P 00:000:00000 12:360:00000 P - unknown
+ YEL2  A    2 P 12:360:00000 13:061:00000 P - unknown
+ YEL2  A    3 P 13:061:00000 13:076:00000 P - unknown
+ YEL2  A    4 P 13:076:00000 13:200:36900 P - antenna change
+ YEL2  A    5 P 13:200:36900 00:000:00000 P -
+ YEL2  A    1 P 00:000:00000 00:000:00000 V -
+ YKRO  A    1 P 00:000:00000 04:125:00000 P - receiver change
+ YKRO  A    2 P 04:125:00000 08:274:00000 P - antenna change
+ YKRO  A    3 P 08:274:00000 00:000:00000 P -
+ YKRO  A    1 P 00:000:00000 00:000:00000 V -
+ YRCM  A    1 P 00:000:00000 05:215:00000 P - unknown
+ YRCM  A    2 P 05:215:00000 00:000:00000 P -
+ YRCM  A    1 P 00:000:00000 00:000:00000 V -
+ ZEEB  A    1 P 00:000:00000 10:256:00000 P - antenna change
+ ZEEB  A    2 P 10:256:00000 00:000:00000 P -
+ ZEEB  A    1 P 00:000:00000 00:000:00000 V -
+ ZHN1  A    1 P 00:000:00000 03:107:00000 P - antenna change
+ ZHN1  A    2 P 03:107:00000 07:185:00000 P - antenna change
+ ZHN1  A    3 P 07:185:00000 00:000:00000 P -
+ ZHN1  A    1 P 00:000:00000 00:000:00000 V -
+ ZIMJ  A    1 P 00:000:00000 11:154:00000 P - antenna change
+ ZIMJ  A    2 P 11:154:00000 16:132:00000 P - 
+ ZIMJ  A    3 P 16:132:00000 00:000:00000 P - 
+ ZIMJ  A    1 P 00:000:00000 00:000:00000 V - 
+ ZSU1  A    1 P 00:000:00000 06:080:00000 P - antenna change
+ ZSU1  A    2 P 06:080:00000 00:000:00000 P -
+ ZSU1  A    1 P 00:000:00000 00:000:00000 V -
+ ZWE2  A    1 P 00:000:00000 07:164:43200 P - antenna change
+ ZWE2  A    2 P 07:164:43200 00:000:00000 P -
+ ZWE2  A    1 P 00:000:00000 00:000:00000 V -
+ ZWEN  A    1 P 00:000:00000 95:067:00000 P - receiver change
+ ZWEN  A    2 P 95:067:00000 00:251:00000 P - receiver change
+ ZWEN  A    3 P 00:251:00000 00:265:00000 P - antenna change
+ ZWEN  A    4 P 00:265:00000 04:266:00000 P - antenna change
+ ZWEN  A    5 P 04:266:00000 00:000:00000 P -
+ ZWEN  A    1 P 00:000:00000 00:000:00000 V -
+ BUR1  A    1 P 00:000:00000 07:030:00000 P - P - Pillar
+ BUR1  A    2 P 07:030:00000 07:157:00000 P - P - Pillar
+ BUR1  A    3 P 07:157:00000 00:000:00000 P -
+ BUR1  A    1 P 00:000:00000 00:000:00000 V -
+ MLAK  A    1 P 00:000:00000 10:215:00000 P - P - Antenna
+ MLAK  A    2 P 10:215:00000 00:000:00000 P -
+ MLAK  A    1 P 00:000:00000 00:000:00000 V -
+ BUSS  A    1 P 00:000:00000 09:036:00000 P - P - 
+ BUSS  A    2 P 09:036:00000 00:000:00000 P -
+ BUSS  A    1 P 00:000:00000 00:000:00000 V -
+ GISB  A    1 P 00:000:00000 04:321:00000 P - P - needs
+ GISB  A    2 P 04:321:00000 07:354:00000 P - P - Earthquake
+ GISB  A    3 P 07:354:00000 10:076:00000 P - P - Unknown
+ GISB  A    4 P 10:076:00000 11:018:00000 P - P - Antenna
+ GISB  A    5 P 11:018:00000 11:349:45944 P - P - Earthquake
+ GISB  A    6 P 11:349:45944 14:281:00000 P - P - needs
+ GISB  A    7 P 14:281:00000 16:318:00000 P - P - needs
+ GISB  A    8 P 16:318:00000 19:261:00000 P - P - needs
+ GISB  A    9 P 19:261:00000 00:000:00000 P -
+ GISB  A    1 P 00:000:00000 00:000:00000 V -
+ PYGR  A    1 P 00:000:00000 09:196:33749 P - P - Earthquake
+ PYGR  A    2 P 09:196:33749 16:318:00000 P - P - Earthquake
+ PYGR  A    3 P 16:318:00000 00:000:00000 P -
+ PYGR  A    1 P 00:000:00000 00:000:00000 V -
+ MAVL  A    1 P 00:000:00000 07:288:00000 P - P - Earthquake
+ MAVL  A    2 P 07:288:00000 09:196:33749 P - P - Earthquake
+ MAVL  A    3 P 09:196:33749 10:354:00000 P - P - Antenna
+ MAVL  A    4 P 10:354:00000 11:202:00000 P - P - Antenna
+ MAVL  A    5 P 11:202:00000 00:000:00000 P -
+ MAVL  A    1 P 00:000:00000 00:000:00000 V -
+ LEXA  A    1 P 00:000:00000 09:196:33749 P - P - Earthquake
+ LEXA  A    2 P 09:196:33749 16:318:00000 P - P - Earthquake
+ LEXA  A    3 P 16:318:00000 00:000:00000 P -
+ LEXA  A    1 P 00:000:00000 00:000:00000 V -
+ BEE2  A    1 P 00:000:00000 11:048:00045 P - P - Antenna
+ BEE2  A    2 P 11:048:00045 00:000:00000 P -
+ BEE2  A    1 P 00:000:00000 00:000:00000 V -
+ ARAR  A    1 P 00:000:00000 11:125:00000 P - P - Antenna
+ ARAR  A    2 P 11:125:00000 11:151:00000 P - P - Antenna
+ ARAR  A    3 P 11:151:00000 00:000:00000 P -
+ ARAR  A    1 P 00:000:00000 00:000:00000 V -
+ KRNG  A    1 P 00:000:00000 11:243:00000 P - P - Antenna
+ KRNG  A    2 P 11:243:00000 00:000:00000 P -
+ KRNG  A    1 P 00:000:00000 00:000:00000 V -
+ TATU  A    1 P 00:000:00000 11:168:00000 P - P - Antenna
+ TATU  A    2 P 11:168:00000 12:036:00000 P - P - Unknown
+ TATU  A    3 P 12:036:00000 00:000:00000 P -
+ TATU  A    1 P 00:000:00000 00:000:00000 V -
+ WAIM  A    1 P 00:000:00000 09:196:00000 P - P - Earthquake
+ WAIM  A    2 P 09:196:00000 10:314:00000 P - P - needs
+ WAIM  A    3 P 10:314:00000 16:318:00000 P - P - needs
+ WAIM  A    4 P 16:318:00000 00:000:00000 P -
+ WAIM  A    1 P 00:000:00000 00:000:00000 V -
+ YALL  A    1 P 00:000:00000 11:254:00000 P - P - Unknown
+ YALL  A    2 P 11:254:00000 11:301:00000 P - P - Unknown
+ YALL  A    3 P 11:301:00000 19:058:00000 P - P - Unknown
+ YALL  A    4 P 19:058:00000 00:000:00000 P -
+ YALL  A    1 P 00:000:00000 00:000:00000 V -
+ HAAS  A    1 P 00:000:00000 09:196:00000 P - P - Earthquake
+ HAAS  A    2 P 09:196:00000 16:318:00000 P - P - Earthquake
+ HAAS  A    3 P 16:318:00000 00:000:00000 P -
+ HAAS  A    1 P 00:000:00000 00:000:00000 V -
+ TAUP  A    1 P 00:000:00000 05:243:00000 P - P - needs
+ TAUP  A    2 P 05:243:00000 11:349:45944 P - P - Earthquake
+ TAUP  A    3 P 11:349:45944 16:318:00000 P - P - Earthquake
+ TAUP  A    4 P 16:318:00000 00:000:00000 P -
+ TAUP  A    1 P 00:000:00000 00:000:00000 V -
+ BALL  A    1 P 00:000:00000 11:124:00000 P - P - needs
+ BALL  A    2 P 11:124:00000 00:000:00000 P -
+ BALL  A    1 P 00:000:00000 00:000:00000 V -
+ BATH  A    1 P 00:000:00000 11:124:00000 P - P - needs
+ BATH  A    2 P 11:124:00000 00:000:00000 P -
+ BATH  A    1 P 00:000:00000 00:000:00000 V -
+ BRBA  A    1 P 00:000:00000 12:248:00000 P - P - needs
+ BRBA  A    2 P 12:248:00000 15:056:00000 P - P - needs
+ BRBA  A    3 P 15:056:00000 00:000:00000 P -
+ BRBA  A    1 P 00:000:00000 00:000:00000 V -
+ BUXT  A    1 P 00:000:00000 13:058:00000 P - P - needs
+ BUXT  A    2 P 13:058:00000 00:000:00000 P -
+ BUXT  A    1 P 00:000:00000 00:000:00000 V -
+ CBLE  A    1 P 00:000:00000 14:057:00000 P - P - needs
+ CBLE  A    2 P 14:057:00000 00:000:00000 P -
+ CBLE  A    1 P 00:000:00000 00:000:00000 V -
+ CBRA  A    1 P 00:000:00000 14:344:00000 P - P - needs
+ CBRA  A    2 P 14:344:00000 15:182:00000 P - P - needs
+ CBRA  A    3 P 15:182:00000 00:000:00000 P -
+ CBRA  A    1 P 00:000:00000 00:000:00000 V -
+ CRDX  A    1 P 00:000:00000 15:063:00000 P - P - needs
+ CRDX  A    2 P 15:063:00000 00:000:00000 P -
+ CRDX  A    1 P 00:000:00000 00:000:00000 V -
+ DLQN  A    1 P 00:000:00000 15:063:00000 P - P - needs
+ DLQN  A    2 P 15:063:00000 00:000:00000 P -
+ DLQN  A    1 P 00:000:00000 00:000:00000 V -
+ DORR  A    1 P 00:000:00000 14:050:00000 P - P - needs
+ DORR  A    2 P 14:050:00000 17:186:00000 P - P - needs
+ DORR  A    3 P 17:186:00000 00:000:00000 P -
+ DORR  A    1 P 00:000:00000 00:000:00000 V -
+ DWNI  A    1 P 00:000:00000 13:037:00000 P - P - needs
+ DWNI  A    2 P 13:037:00000 00:000:00000 P -
+ DWNI  A    1 P 00:000:00000 00:000:00000 V -
+ FORB  A    1 P 00:000:00000 12:255:00000 P - P - needs
+ FORB  A    2 P 12:255:00000 00:000:00000 P -
+ FORB  A    1 P 00:000:00000 00:000:00000 V -
+ GATT  A    1 P 00:000:00000 15:231:00000 P - P - needs
+ GATT  A    2 P 15:231:00000 16:356:00000 P - P - needs
+ GATT  A    3 P 16:356:00000 00:000:00000 P -
+ GATT  A    1 P 00:000:00000 00:000:00000 V -
+ GILG  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ GILG  A    2 P 14:043:00000 00:000:00000 P -
+ GILG  A    1 P 00:000:00000 00:000:00000 V -
+ GLIN  A    1 P 00:000:00000 15:042:00000 P - P - needs
+ GLIN  A    2 P 15:042:00000 00:000:00000 P -
+ GLIN  A    1 P 00:000:00000 00:000:00000 V -
+ HILL  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ HILL  A    2 P 14:043:00000 00:000:00000 P -
+ HILL  A    1 P 00:000:00000 00:000:00000 V -
+ HKNP  A    1 P 00:000:00000 11:220:00000 P - P - needs
+ HKNP  A    2 P 11:220:00000 00:000:00000 P -
+ HKNP  A    1 P 00:000:00000 00:000:00000 V -
+ HKSL  A    1 P 00:000:00000 12:094:00000 P - P - needs
+ HKSL  A    2 P 12:094:00000 00:000:00000 P -
+ HKSL  A    1 P 00:000:00000 00:000:00000 V -
+ HKWS  A    1 P 00:000:00000 12:094:00000 P - P - needs
+ HKWS  A    2 P 12:094:00000 00:000:00000 P -
+ HKWS  A    1 P 00:000:00000 00:000:00000 V -
+ HLBK  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ HLBK  A    2 P 14:043:00000 00:000:00000 P -
+ HLBK  A    1 P 00:000:00000 00:000:00000 V -
+ HOKI  A    1 P 00:000:00000 10:251:00000 P - P - needs
+ HOKI  A    2 P 10:251:00000 16:321:00000 P - P - needs
+ HOKI  A    3 P 16:321:00000 00:000:00000 P -
+ HOKI  A    1 P 00:000:00000 00:000:00000 V -
+ MLO1  A    1 P 00:000:00000 13:317:00000 P - P - needs
+ MLO1  A    2 P 13:317:00000 18:124:81174 P - P - EQ
+ MLO1  A    3 P 18:124:81174 00:000:00000 P -
+ MLO1  A    1 P 00:000:00000 00:000:00000 V -
+ MTBU  A    1 P 00:000:00000 13:023:00000 P - P - needs
+ MTBU  A    2 P 13:023:00000 14:036:00000 P - P - needs
+ MTBU  A    3 P 14:036:00000 00:000:00000 P -
+ MTBU  A    1 P 00:000:00000 00:000:00000 V -
+ MWAL  A    1 P 00:000:00000 13:261:00000 P - P - needs
+ MWAL  A    2 P 13:261:00000 14:050:00000 P - P - needs
+ MWAL  A    3 P 14:050:00000 00:000:00000 P -
+ MWAL  A    1 P 00:000:00000 00:000:00000 V -
+ NRMN  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ NRMN  A    2 P 14:043:00000 00:000:00000 P -
+ NRMN  A    1 P 00:000:00000 00:000:00000 V -
+ NTJN  A    1 P 00:000:00000 13:177:00000 P - P - needs
+ NTJN  A    2 P 13:177:00000 00:000:00000 P -
+ NTJN  A    1 P 00:000:00000 00:000:00000 V -
+ PMAC  A    1 P 00:000:00000 12:332:00000 P - P - needs
+ PMAC  A    2 P 12:332:00000 17:298:00000 P - P - needs
+ PMAC  A    3 P 17:298:00000 00:000:00000 P -
+ PMAC  A    1 P 00:000:00000 00:000:00000 V -
+ RAND  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ RAND  A    2 P 14:043:00000 15:280:00000 P - P - needs
+ RAND  A    3 P 15:280:00000 00:000:00000 P -
+ RAND  A    1 P 00:000:00000 00:000:00000 V -
+ RANK  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ RANK  A    2 P 14:043:00000 00:000:00000 P -
+ RANK  A    1 P 00:000:00000 00:000:00000 V -
+ ROBI  A    1 P 00:000:00000 09:001:00000 P - P - needs
+ ROBI  A    2 P 09:001:00000 16:251:00000 P - P - needs
+ ROBI  A    3 P 16:251:00000 00:000:00000 P -
+ ROBI  A    1 P 00:000:00000 00:000:00000 V -
+ RUUS  A    1 P 00:000:00000 15:063:00000 P - P - needs
+ RUUS  A    2 P 15:063:00000 15:301:00000 P - P - needs
+ RUUS  A    3 P 15:301:00000 00:000:00000 P -
+ RUUS  A    1 P 00:000:00000 00:000:00000 V -
+ SCTB  A    1 P 00:000:00000 11:005:00000 P - P - needs
+ SCTB  A    2 P 11:005:00000 00:000:00000 P -
+ SCTB  A    1 P 00:000:00000 00:000:00000 V -
+ SOLO  A    1 P 00:000:00000 09:280:00000 P - P - needs
+ SOLO  A    2 P 09:280:00000 12:157:00000 P - P - needs
+ SOLO  A    3 P 12:157:00000 16:349:00000 P - P - needs
+ SOLO  A    4 P 16:349:00000 00:000:00000 P -
+ SOLO  A    1 P 00:000:00000 00:000:00000 V -
+ TELO  A    1 P 00:000:00000 13:044:00000 P - P - needs
+ TELO  A    2 P 13:044:00000 14:099:00000 P - P - needs
+ TELO  A    3 P 14:099:00000 00:000:00000 P -
+ TELO  A    1 P 00:000:00000 00:000:00000 V -
+ TMRA  A    1 P 00:000:00000 14:043:00000 P - P - needs
+ TMRA  A    2 P 14:043:00000 00:000:00000 P -
+ TMRA  A    1 P 00:000:00000 00:000:00000 V -
+ VGMT  A    1 P 00:000:00000 15:033:00000 P - P - needs
+ VGMT  A    2 P 15:033:00000 16:318:00000 P - P - needs
+ VGMT  A    3 P 16:318:00000 00:000:00000 P -
+ VGMT  A    1 P 00:000:00000 00:000:00000 V -
+ WEEM  A    1 P 00:000:00000 15:056:00000 P - P - needs
+ WEEM  A    2 P 15:056:00000 00:000:00000 P -
+ WEEM  A    1 P 00:000:00000 00:000:00000 V -
+ WEIP  A    1 P 00:000:00000 13:072:00000 P - P - needs
+ WEIP  A    2 P 13:072:00000 00:000:00000 P -
+ WEIP  A    1 P 00:000:00000 00:000:00000 V -
+ WFAL  A    1 P 00:000:00000 15:063:00000 P - P - needs
+ WFAL  A    2 P 15:063:00000 00:000:00000 P -
+ WFAL  A    1 P 00:000:00000 00:000:00000 V -
+ WHNG  A    1 P 00:000:00000 05:003:00000 P - P - needs
+ WHNG  A    2 P 05:003:00000 11:005:00000 P - P - needs
+ WHNG  A    3 P 11:005:00000 16:318:00000 P - P - needs
+ WHNG  A    4 P 16:318:00000 00:000:00000 P -
+ WHNG  A    1 P 00:000:00000 00:000:00000 V -
+ YASS  A    1 P 00:000:00000 14:063:00000 P - P - needs
+ YASS  A    2 P 14:063:00000 00:000:00000 P -
+ YASS  A    1 P 00:000:00000 00:000:00000 V -
+ YULA  A    1 P 00:000:00000 13:324:00000 P - P - needs
+ YULA  A    2 P 13:324:00000 00:000:00000 P -
+ YULA  A    1 P 00:000:00000 00:000:00000 V -
+ CORD  A    1 P 00:000:00000 15:260:00000 P - P - needs
+ CORD  A    2 P 15:260:00000 00:000:00000 P -
+ CORD  A    1 P 00:000:00000 00:000:00000 V -
+ GWAB  A    1 P 00:000:00000 16:126:00000 P - P - needs
+ GWAB  A    2 P 16:126:00000 00:000:00000 P -
+ GWAB  A    1 P 00:000:00000 00:000:00000 V -
+ INVL  A    1 P 00:000:00000 16:168:00000 P - P - needs
+ INVL  A    2 P 16:168:00000 00:000:00000 P -
+ INVL  A    1 P 00:000:00000 00:000:00000 V -
+ MCHL  A    1 P 00:000:00000 16:098:00000 P - P - needs
+ MCHL  A    2 P 16:098:00000 00:000:00000 P -
+ MCHL  A    1 P 00:000:00000 00:000:00000 V -
+ WDBG  A    1 P 00:000:00000 16:168:00000 P - P - needs
+ WDBG  A    2 P 16:168:00000 00:000:00000 P -
+ WDBG  A    1 P 00:000:00000 00:000:00000 V -
+ WYNG  A    1 P 00:000:00000 16:042:00000 P - P - needs
+ WYNG  A    2 P 16:042:00000 00:000:00000 P -
+ WYNG  A    1 P 00:000:00000 00:000:00000 V -
+ ANNA  A    1 P 00:000:00000 17:214:00000 P - P - needs
+ ANNA  A    2 P 17:214:00000 00:000:00000 P -
+ ANNA  A    1 P 00:000:00000 00:000:00000 V -
+ ANTW  A    1 P 00:000:00000 13:051:00000 P - P - needs
+ ANTW  A    2 P 13:051:00000 17:298:00000 P - P - needs
+ ANTW  A    3 P 17:298:00000 00:000:00000 P -
+ ANTW  A    1 P 00:000:00000 00:000:00000 V -
+ BALN  A    1 P 00:000:00000 17:179:00000 P - P - needs
+ BALN  A    2 P 17:179:00000 00:000:00000 P -
+ BALN  A    1 P 00:000:00000 00:000:00000 V -
+ BEUA  A    1 P 00:000:00000 15:161:00000 P - P - needs
+ BEUA  A    2 P 15:161:00000 00:000:00000 P -
+ BEUA  A    1 P 00:000:00000 00:000:00000 V -
+ BLCK  A    1 P 00:000:00000 17:186:00000 P - P - needs
+ BLCK  A    2 P 17:186:00000 00:000:00000 P -
+ BLCK  A    1 P 00:000:00000 00:000:00000 V -
+ CLEV  A    1 P 00:000:00000 15:182:00000 P - P - needs
+ CLEV  A    2 P 15:182:00000 17:270:00000 P - P - needs
+ CLEV  A    3 P 17:270:00000 00:000:00000 P -
+ CLEV  A    1 P 00:000:00000 00:000:00000 V -
+ COLE  A    1 P 00:000:00000 17:165:00000 P - P - needs
+ COLE  A    2 P 17:165:00000 00:000:00000 P -
+ COLE  A    1 P 00:000:00000 00:000:00000 V -
+ HAMT  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ HAMT  A    2 P 16:318:00000 00:000:00000 P -
+ HAMT  A    1 P 00:000:00000 00:000:00000 V -
+ HATT  A    1 P 00:000:00000 13:037:00000 P - P - needs
+ HATT  A    2 P 13:037:00000 00:000:00000 P -
+ HATT  A    1 P 00:000:00000 00:000:00000 V -
+ HIKB  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ HIKB  A    2 P 16:318:00000 00:000:00000 P -
+ HIKB  A    1 P 00:000:00000 00:000:00000 V -
+ IHOE  A    1 P 00:000:00000 16:356:00000 P - P - needs
+ IHOE  A    2 P 16:356:00000 00:000:00000 P -
+ IHOE  A    1 P 00:000:00000 00:000:00000 V -
+ KUNU  A    1 P 00:000:00000 17:025:00000 P - P - needs
+ KUNU  A    2 P 17:025:00000 00:000:00000 P -
+ KUNU  A    1 P 00:000:00000 00:000:00000 V -
+ MAHO  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ MAHO  A    2 P 16:318:00000 00:000:00000 P -
+ MAHO  A    1 P 00:000:00000 00:000:00000 V -
+ ORNG  A    1 P 00:000:00000 17:319:00000 P - P - needs
+ ORNG  A    2 P 17:319:00000 00:000:00000 P -
+ ORNG  A    1 P 00:000:00000 00:000:00000 V -
+ TDOU  A    1 P 00:000:00000 16:130:00000 P - P - needs
+ TDOU  A    2 P 16:130:00000 00:000:00000 P -
+ TDOU  A    1 P 00:000:00000 00:000:00000 V -
+ UNDE  A    1 P 00:000:00000 17:137:00000 P - P - needs
+ UNDE  A    2 P 17:137:00000 00:000:00000 P -
+ UNDE  A    1 P 00:000:00000 00:000:00000 V -
+ WANG  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ WANG  A    2 P 16:318:00000 00:000:00000 P -
+ WANG  A    1 P 00:000:00000 00:000:00000 V -
+ OWMG  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ OWMG  A    2 P 16:318:00000 00:000:00000 P -
+ OWMG  A    1 P 00:000:00000 00:000:00000 V -
+ METH  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ METH  A    2 P 16:318:00000 00:000:00000 P -
+ METH  A    1 P 00:000:00000 00:000:00000 V -
+ MRL1  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ MRL1  A    2 P 16:318:00000 00:000:00000 P -
+ MRL1  A    1 P 00:000:00000 00:000:00000 V -
+ MRL2  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ MRL2  A    2 P 16:318:00000 00:000:00000 P -
+ MRL2  A    1 P 00:000:00000 00:000:00000 V -
+ DNVK  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ DNVK  A    2 P 16:318:00000 00:000:00000 P -
+ DNVK  A    1 P 00:000:00000 00:000:00000 V -
+ HAST  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ HAST  A    2 P 16:318:00000 00:000:00000 P -
+ HAST  A    1 P 00:000:00000 00:000:00000 V -
+ WHKT  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ WHKT  A    2 P 16:318:00000 00:000:00000 P -
+ WHKT  A    1 P 00:000:00000 00:000:00000 V -
+ TRNG  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ TRNG  A    2 P 16:318:00000 00:000:00000 P -
+ TRNG  A    1 P 00:000:00000 00:000:00000 V -
+ CORM  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ CORM  A    2 P 16:318:00000 00:000:00000 P -
+ CORM  A    1 P 00:000:00000 00:000:00000 V -
+ KTIA  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ KTIA  A    2 P 16:318:00000 00:000:00000 P -
+ KTIA  A    1 P 00:000:00000 00:000:00000 V -
+ MUDG  A    1 P 00:000:00000 16:318:00000 P - P - needs
+ MUDG  A    2 P 16:318:00000 00:000:00000 P -
+ MUDG  A    1 P 00:000:00000 00:000:00000 V -
+ ALBU  A    1 P 00:000:00000 13:359:00000 P - P - needs
+ ALBU  A    2 P 13:359:00000 00:000:00000 P -
+ ALBU  A    1 P 00:000:00000 00:000:00000 V -
+ PRCE  A    1 P 00:000:00000 16:237:00000 P - P - needs
+ PRCE  A    2 P 16:237:00000 00:000:00000 P -
+ PRCE  A    1 P 00:000:00000 00:000:00000 V -
+ WARW  A    1 P 00:000:00000 17:284:00000 P - P - needs
+ WARW  A    2 P 17:284:00000 00:000:00000 P -
+ WARW  A    1 P 00:000:00000 00:000:00000 V -
+ PKVL  A    1 P 00:000:00000 17:351:00000 P - P - Antenna
+ PKVL  A    2 P 17:351:00000 00:000:00000 P -
+ PKVL  A    1 P 00:000:00000 00:000:00000 V -
+ ARRT  A    1 P 00:000:00000 18:164:00000 P - P - unknown
+ ARRT  A    2 P 18:164:00000 00:000:00000 P -
+ ARRT  A    1 P 00:000:00000 00:000:00000 V -
+ CA19  A    1 P 00:000:00000 18:182:00000 P - P - Mining
+ CA19  A    2 P 18:182:00000 00:000:00000 P -
+ CA19  A    1 P 00:000:00000 00:000:00000 V -
+ KOK5  A    1 P 00:000:00000 17:172:00000 P - P - unknown
+ KOK5  A    2 P 17:172:00000 00:000:00000 P -
+ KOK5  A    1 P 00:000:00000 00:000:00000 V -
+ KTON  A    1 P 00:000:00000 18:157:00000 P - P - unknown
+ KTON  A    2 P 18:157:00000 00:000:00000 P -
+ KTON  A    1 P 00:000:00000 00:000:00000 V -
+ DRGO  A    1 P 00:000:00000 18:178:00000 P - P - unknown
+ DRGO  A    2 P 18:178:00000 00:000:00000 P -
+ DRGO  A    1 P 00:000:00000 00:000:00000 V -
+ LGOW  A    1 P 00:000:00000 18:290:00000 P - P - unknown
+ LGOW  A    2 P 18:290:00000 00:000:00000 P -
+ LGOW  A    1 P 00:000:00000 00:000:00000 V -
+ MGRV  A    1 P 00:000:00000 17:186:00000 P - P - unknown
+ MGRV  A    2 P 17:186:00000 00:000:00000 P -
+ MGRV  A    1 P 00:000:00000 00:000:00000 V -
+ NGAN  A    1 P 00:000:00000 18:143:00000 P - P - unknown
+ NGAN  A    2 P 18:143:00000 00:000:00000 P -
+ NGAN  A    1 P 00:000:00000 00:000:00000 V -
+ NHIL  A    1 P 00:000:00000 18:213:00000 P - P - unknown
+ NHIL  A    2 P 18:213:00000 00:000:00000 P -
+ NHIL  A    1 P 00:000:00000 00:000:00000 V -
+ RVO_  A    1 P 00:000:00000 14:141:00000 P - P - Volcano
+ RVO_  A    2 P 14:141:00000 15:001:00000 P - P - Volcano
+ RVO_  A    3 P 15:001:00000 00:000:00000 P -
+ RVO_  A    1 P 00:000:00000 00:000:00000 V -
+ SNGO  A    1 P 00:000:00000 18:171:00000 P - P - unknown
+ SNGO  A    2 P 18:171:00000 00:000:00000 P -
+ SNGO  A    1 P 00:000:00000 00:000:00000 V -
+ TAMW  A    1 P 00:000:00000 18:164:00000 P - P - unknown
+ TAMW  A    2 P 18:164:00000 00:000:00000 P -
+ TAMW  A    1 P 00:000:00000 00:000:00000 V -
+ YARO  A    1 P 00:000:00000 18:052:00000 P - P - unknown
+ YARO  A    2 P 18:052:00000 00:000:00000 P -
+ YARO  A    1 P 00:000:00000 00:000:00000 V -
+ GELA  A    1 P 00:000:00000 19:163:00000 P - P - unknown
+ GELA  A    2 P 19:163:00000 00:000:00000 P -
+ GELA  A    1 P 00:000:00000 00:000:00000 V -
+-SOLUTION/DISCONTINUITY
+*----------------------------------------------------------------
+%ENDSNX


### PR DESCRIPTION
This pull request addresses #15 in the context of **import**, fixes a defect in the output of station uncertainties in the adj file, and provides some general enhancements that deal with certain compiler warnings and [Codacy](https://app.codacy.com/gh/icsm-au/DynAdjust/dashboard) issues. In relation to #15, **import** now applies discontinuity renaming to station names imported in DNA and DynaML files and takes this renaming into account when supplying station names on the command line for `--include-stns-assoc-msrs` or `--exclude-stns-assoc-msrs`. A sample discontinuity file (disconts20201205.snx) has been added to the [sampleData](https://github.com/icsm-au/DynAdjust/tree/master/sampleData) folder, and new test scripts have been added.