### PR TITLE
Geoid log file improvements and updates to the User's Guide

### DIFF
--- a/dynadjust/dynadjust/dnageoid/dnageoid.cpp
+++ b/dynadjust/dynadjust/dnageoid/dnageoid.cpp
@@ -84,15 +84,27 @@ string dna_geoid_interpolation::ReturnBadStationRecords()
 {
 	stringstream ssPoints;
 
-	it_vstn_t stn_it;
+	ssPoints << setw(STATION) << left << "Station" <<
+		setw(PAD2) << " " << 
+		right << setw(LAT_EAST) << "Latitude" << 
+		right << setw(LON_NORTH) << "Longitude" << 
+		right << setw(LON_NORTH) << "Error code" << endl;
 
-	for (stn_it=bstBadPoints_.begin(); stn_it!=bstBadPoints_.end(); ++stn_it)
+	UINT32 i, j = STATION+PAD2+LAT_EAST+LON_NORTH+LON_NORTH;
+
+	for (i=0; i<j; ++i)
+		ssPoints << "-";
+	ssPoints << endl;
+
+	for (it_stn_string stn_it = bstBadPoints_.begin(); 
+		stn_it!=bstBadPoints_.end(); 
+		++stn_it)
 	{
-		ssPoints << fixed << setprecision(9) <<
-			"   " <<
-			stn_it->stationName << ", " <<
-			setw(14) << FormatDmsString(RadtoDms(stn_it->currentLatitude), 7, true, false) << ", " <<
-			setw(14) << FormatDmsString(RadtoDms(stn_it->currentLongitude), 7, true, false) << endl;
+		ssPoints << setw(STATION) << left << stn_it->first.stationName <<
+			setw(PAD2) << " " <<			
+			right << setw(LAT_EAST) << FormatDmsString(RadtoDms(stn_it->first.currentLatitude), 7, true, false) << 
+			right << setw(LON_NORTH) << FormatDmsString(RadtoDms(stn_it->first.currentLongitude), 7, true, false) << 
+			right << setw(LON_NORTH) << stn_it->second << endl;
 	}
 
 	return ssPoints.str();
@@ -107,6 +119,8 @@ void dna_geoid_interpolation::PopulateStationRecords(const int& method, bool con
 	m_pointsInterpolated = m_pointsNotInterpolated = 0;
 	bstBadPoints_.clear();
 
+	stn_t_string_pair bad_point;
+
 	for (stn_it=bstBinaryRecords_.begin(); stn_it!=bstBinaryRecords_.end(); ++stn_it)
 	{
 		dlat = m_pGridfile->dLat = stn_it->currentLatitude * RAD_TO_SEC;
@@ -118,7 +132,9 @@ void dna_geoid_interpolation::PopulateStationRecords(const int& method, bool con
 		case ERR_PT_OUTSIDE_GRID:		// 13
 		case ERR_FINDSUBGRID_OUTSIDE:	// -1
 			++m_pointsNotInterpolated;
-			bstBadPoints_.push_back(*stn_it);
+			bad_point.first = *stn_it;
+			bad_point.second = StringFromT(agCoord.cVar.IO_Status);
+			bstBadPoints_.push_back(bad_point);
 			continue;					// this point is outside the grid file extents
 		case ERR_TRANS_SUCCESS:
 			break;						// success

--- a/dynadjust/dynadjust/dnageoid/dnageoid.hpp
+++ b/dynadjust/dynadjust/dnageoid/dnageoid.hpp
@@ -253,7 +253,7 @@ private:
 	binary_file_meta_t	bst_meta_;
 	
 	vstn_t				bstBinaryRecords_;
-	vstn_t				bstBadPoints_;
+	v_stn_string		bstBadPoints_;
 
 	UINT32				m_pointsInterpolated;
 	UINT32				m_pointsNotInterpolated;

--- a/dynadjust/dynadjust/dnageoidwrapper/dnageoidwrapper.cpp
+++ b/dynadjust/dynadjust/dnageoidwrapper/dnageoidwrapper.cpp
@@ -155,9 +155,9 @@ void ReturnBadStationRecords(dna_geoid_interpolation* g, project_settings& p)
 	badpoints_log << setw(PRINT_VAR_PAD) << left << "Network name:" <<  p.g.network_name << endl;
 	badpoints_log << setw(PRINT_VAR_PAD) << left << "Stations file:" << system_complete(p.n.bst_file).string() << endl;
 	badpoints_log << setw(PRINT_VAR_PAD) << left << "Geoid model: " << system_complete(p.n.ntv2_geoid_file).string() << endl << endl;
-
-	badpoints_log << setw(PRINT_VAR_PAD) << left << "Stations not interpolated:" << g->PointsNotInterpolated() << endl << endl;
-
+	badpoints_log << setw(PRINT_VAR_PAD) << left << "Stations not interpolated:" << g->PointsNotInterpolated() << endl;
+	badpoints_log << OUTPUTLINE << endl << endl;
+	
 	records = g->ReturnBadStationRecords();
 
 	badpoints_log << records << endl;

--- a/dynadjust/dynadjust/dnaimport/dnainterop.cpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.cpp
@@ -3880,7 +3880,7 @@ void dna_import::SignalExceptionParseDNA(const string& message, const string& sB
 	
 
 // Name:				SignalExceptionInterop
-// Purpose:				Closes all files (if file pointers are passed in) and throws NetSegmentException
+// Purpose:				Closes all files (if file pointers are passed in) and throws XMLInteropException
 // Called by:			Any
 // Calls:				XMLInteropException()
 void dna_import::SignalExceptionInterop(string msg, int i, const char *streamType, ...)

--- a/dynadjust/include/config/dnatypes.hpp
+++ b/dynadjust/include/config/dnatypes.hpp
@@ -578,6 +578,10 @@ typedef vstn_t::iterator it_vstn_t;
 typedef vstn_t::const_iterator it_vstn_t_const;
 typedef vector<statSummary_t> vsummary_t, *pvsummary_t;
 
+typedef pair <station_t, string> stn_t_string_pair;
+typedef vector<stn_t_string_pair> v_stn_string;
+typedef v_stn_string::iterator it_stn_string;
+
 const UINT32 MOD_NAME_WIDTH(20);
 const UINT32 FILE_NAME_WIDTH(256);
 


### PR DESCRIPTION
## Overview

This pull request provides changes and updates as follows.

### geoid

- In the context of logging points to the geoid interpolation log file when stations cannot be interpolated, print a table header and add the error code for each station in the table.

### DynAdjust User's Guide

- Help on sorting the measurements to station output (c.f. #87)
- Help on exporting estimated station coordinates and uncertainties as a GNSS Y cluster to DNA and DynaML formats (c.f. #92)
- Help on generating a geoid interpolation log file (c.f. #108)
- Updates to **Appendix A Command line reference** for:
   - **import** (c.f. #87)
   - **geoid** (c.f. #108)
   - **adjust** (c.f. #87, #92)
   - **plot** (c.f. #139)
- Updates to **Appendix B File format specification** for:
   - Measurement to station (`*.m2s`) file (c.f. #87)
   - Geoid interpolation file (`*.int`) file (c.f. #108)

