### PR TITLE
Final code changes to close #15

### DIFF
--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -298,6 +298,7 @@ if (BUILD_TESTING)
     add_test (NAME imp-discont-01 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx --export-discont-file)
     add_test (NAME imp-discont-02 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx --split-gnss --include-stn "ALIC" --export-dna)
     add_test (NAME imp-discont-03 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2014 --override-input-ref-frame ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX ${CMAKE_SOURCE_DIR}/../sampleData/sa-gnss-stn.xml ${CMAKE_SOURCE_DIR}/../sampleData/sa-gnss-msr.xml --prefer-single-x-as-g --flag-unused --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx --remove-ignored-msr --split-gnss --include-stns-assoc-msrs "ALIC" --export-dna --export-xml)
+    add_test (NAME adj-discont-01 COMMAND $<TARGET_FILE:dnaadjustwrapper> discont --constraint "ALIC,CCC")
     add_test (NAME imp-discont-04 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2005 ${CMAKE_SOURCE_DIR}/../sampleData/TEST_ITRF05.SNX --export-xml)
     add_test (NAME imp-discont-05 COMMAND $<TARGET_FILE:dnaimportwrapper> -n discont -r itrf2000 --override-input-ref-frame ./discontstn.xml ./discontmsr.xml --discontinuity-file ${CMAKE_SOURCE_DIR}/../sampleData/disconts20201205.snx)
     

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
@@ -460,6 +460,7 @@ private:
 	
 	// Adjustment helps
 	void ApplyAdditionalConstraints();
+	void AddDiscontinuitySites(vstring& constraintStns);
 	void LoadStationMap(pv_string_uint32_pair stnsMap, const string& stnmap_file);
 	void ResizeMatrixVectors();
 	void LoadPhasedBlocks();

--- a/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustwrapper.cpp
+++ b/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustwrapper.cpp
@@ -1085,8 +1085,12 @@ int main(int argc, char* argv[])
 		if (p.a.scale_normals_to_unity)
 			cout << setw(PRINT_VAR_PAD) << left << "  Scale normals to unity: " << "yes" << endl;
 		if (!p.a.station_constraints.empty())
+		{
 			cout << setw(PRINT_VAR_PAD) << left << "  Station constraints: " << p.a.station_constraints << endl;
-		
+			if (p.i.apply_discontinuities)
+				cout << setw(PRINT_VAR_PAD) << left << "  Apply discontinuities: " << "yes" << endl;
+		}
+
 		switch (p.a.adjust_mode)
 		{
 		case Phased_Block_1Mode:

--- a/dynadjust/dynadjust/dnaimport/dnainterop.cpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.cpp
@@ -787,6 +787,7 @@ void dna_import::AddDiscontinuityStations(vdnaStnPtr* vStations)
 			// the duplicate having a larger file order, via SetfileOrder(++station_index) below.
 			
 			stn_ptr.reset(vStations->at(i)->clone());
+			stn_ptr->SetOriginalName();
 			stn_ptr->SetName(stn_renames_it->second);
 			stn_ptr->SetfileOrder(++station_index);
 			vStations->push_back(stn_ptr);

--- a/dynadjust/include/config/dnaprojectfile.cpp
+++ b/dynadjust/include/config/dnaprojectfile.cpp
@@ -924,6 +924,7 @@ void CDnaProjectFile::LoadSettingImport(const settingMode mSetting, const string
 		if (val.empty())
 			return;
 		settings_.i.stn_discontinuityfile = formPath<string>(settings_.g.input_folder, val);
+		settings_.i.apply_discontinuities = true;
 	}
 	else if (iequals(var, TEST_NEARBY_STNS))
 	{

--- a/dynadjust/include/config/dnatypes.hpp
+++ b/dynadjust/include/config/dnatypes.hpp
@@ -517,6 +517,7 @@ typedef struct block_meta {
 } blockMeta_t;
 
 const UINT16 STN_NAME_WIDTH(31);
+const UINT16 STN_NAME_ORIG_WIDTH(40);
 const UINT16 STN_DESC_WIDTH(129);
 const UINT16 STN_CONST_WIDTH(4);
 const UINT16 STN_TYPE_WIDTH(4);
@@ -533,6 +534,7 @@ typedef struct stn_t {
 		, fileOrder(0), nameOrder(0), clusterID(0), unusedStation(FALSE) 
 	{
 		memset(stationName, '\0', sizeof(stationName));
+		memset(stationNameOrig, '\0', sizeof(stationNameOrig));
 		memset(stationConst, '\0', sizeof(stationConst));
 		memset(stationType, '\0', sizeof(stationType));
 		memset(description, '\0', sizeof(description));
@@ -543,12 +545,13 @@ typedef struct stn_t {
 		memset(plate, '\0', sizeof(plate));
 	}
 
-	char	stationName[STN_NAME_WIDTH];	// 30 characters
-	char	stationConst[STN_CONST_WIDTH];	// constraint: lat, long, height
-	char	stationType[STN_TYPE_WIDTH];	// type: LLH, UTM, XYZ
-	UINT16	suppliedStationType;			// type supplied by the user (required for adjust)
-	double	initialLatitude;				// initial estimate
-	double	currentLatitude;				// current estimate
+	char	stationName[STN_NAME_WIDTH];			// 30 characters
+	char    stationNameOrig[STN_NAME_ORIG_WIDTH];	// 39 characters: 30 (name) + 1 (_) + 8 (date)
+	char	stationConst[STN_CONST_WIDTH];			// constraint: lat, long, height
+	char	stationType[STN_TYPE_WIDTH];			// type: LLH, UTM, XYZ
+	UINT16	suppliedStationType;					// type supplied by the user (required for adjust)
+	double	initialLatitude;						// initial estimate
+	double	currentLatitude;						// current estimate
 	double	initialLongitude;
 	double	currentLongitude;
 	double	initialHeight;					// initialHeight and currentHeight are always assumed to be

--- a/dynadjust/include/functions/dnatemplatefuncs.hpp
+++ b/dynadjust/include/functions/dnatemplatefuncs.hpp
@@ -1040,6 +1040,34 @@ public:
 };
 
 
+// T = station_t, S = string
+template<typename T>
+class CompareStnName
+{
+public:
+	bool operator()(const T& lhs, const T& rhs) {
+		return string(lhs.stationName) < string(rhs.stationName);
+	}
+};
+
+
+// T = station_t, S = string
+template<typename T, typename S>
+class CompareStnOriginalName
+{
+public:
+	bool operator()(const T& lhs, const T& rhs) {
+		return string(lhs.stationNameOrig) < string(rhs.stationNameOrig);
+	}
+	bool operator()(const T& lhs, const S& rhs) {
+		return string(lhs.stationNameOrig) < rhs;
+	}
+	bool operator()(const S& lhs, const T& rhs) {
+		return lhs < string(rhs.stationNameOrig);
+	}
+};
+
+
 // S = station_t, U = UINT32
 template<typename S, typename U>
 class CompareStnLongitude

--- a/dynadjust/include/io/dnaiosnx.hpp
+++ b/dynadjust/include/io/dnaiosnx.hpp
@@ -177,20 +177,18 @@ bool rename_discont_station(T& begin, S& site_name, D& site_date, S& site_rename
 			{
 				// format using the start epoch
 				// year
-				ss << dateYear<UINT32>(site_date);
+				year << dateYear<UINT32>(site_date);
 				// doy
-				ss << dateDOY<UINT32>(site_date);
+				doy = dateDOY<UINT32>(site_date);
+					
 			}
-			else
-			{
-				// format using the discontinuity date
-				ss << year;
-				if (doy < 10)
-					ss << "0";
-				if (doy < 100)
-					ss << "0";
-				ss << doy;
-			}
+
+			ss << year;
+			if (doy < 100)
+				ss << "0";
+			if (doy < 10)
+				ss << "0";
+			ss << doy;
 
 			site_renamed = ss.str();
 

--- a/dynadjust/include/io/dnaiosnxread.cpp
+++ b/dynadjust/include/io/dnaiosnxread.cpp
@@ -408,18 +408,18 @@ void dna_io_snx::format_station_names(v_discontinuity_tuple* stn_discontinuities
 				if (year == DISCONT_TIME_IMMEMORIAL)
 				{
 					// format using the start epoch
-					// year
+					// year (4 chars)
 					ss << siteOccurrence_.at(site).formatted_date.substr(4, 4);
-					// doy
+					// doy (3 chars)
 					ss << siteOccurrence_.at(site).formatted_date.substr(0, 3);
 				}
 				else
 				{
 					// format using the discontinuity date
 					ss << year;
-					if (doy < 10)
-						ss << "0";
 					if  (doy < 100)
+						ss << "0";
+					if (doy < 10)
 						ss << "0";
 					ss << doy;
 				}
@@ -450,7 +450,10 @@ void dna_io_snx::format_station_names(v_discontinuity_tuple* stn_discontinuities
 	for_each(vStations->begin(), vStations->end(),
 		[&_it_site](const dnaStnPtr& stn) {
 			if (!equals(_it_site->site_name, _it_site->formatted_name))
+			{
+				stn->SetOriginalName();
 				stn->SetName(_it_site->formatted_name);
+			}
 			_it_site++;
 	});
 

--- a/dynadjust/include/measurement_types/dnastation.cpp
+++ b/dynadjust/include/measurement_types/dnastation.cpp
@@ -128,7 +128,7 @@ CAStationList& CAStationList::operator =(CAStationList&& rhs)
 
 //<CDnaStation>//
 CDnaStation::CDnaStation(const string& referenceframe, const string& epoch)
-	: m_strName("")
+	: m_strName(""), m_strOriginalName("")
 	, m_dXAxis(0.), m_dYAxis(0.), m_dZAxis(0.), m_dHeight(0.)
 	, m_dStdDevX(0.), m_dStdDevY(0.), m_dStdDevZ(0.), m_dStdDevHt(0.)
 	, m_strConstraints("FFF"), m_strType(""), m_strHemisphereZone(""), m_strDescription(""), m_strComment("")
@@ -151,6 +151,7 @@ CDnaStation::~CDnaStation()
 CDnaStation::CDnaStation(const CDnaStation& newStation)
 {
 	m_strName = newStation.m_strName;
+	m_strOriginalName = newStation.m_strOriginalName;
 	m_strConstraints = newStation.m_strConstraints;
 	m_strType = newStation.m_strType;
 	m_dXAxis = newStation.m_dXAxis;
@@ -194,6 +195,8 @@ CDnaStation::CDnaStation(const string& strName, const string& strConstraints,
 	const string& strComment)
 {
 	m_strName = strName;
+
+	m_strOriginalName = "";
 	
 	SetConstraints(strConstraints);
 	SetCoordType(strType);
@@ -864,6 +867,7 @@ void CDnaStation::WriteBinaryStn(std::ofstream* binary_stream, const UINT16 bUnu
 {
 	station_t stationRecord;
 	strcpy(stationRecord.stationName, m_strName.substr(0, STN_NAME_WIDTH).c_str());
+	strcpy(stationRecord.stationNameOrig, m_strOriginalName.substr(0, STN_NAME_WIDTH).c_str());
 	strcpy(stationRecord.stationConst, m_strConstraints.substr(0, STN_CONST_WIDTH).c_str());
 	strcpy(stationRecord.stationType, m_strType.substr(0, STN_TYPE_WIDTH).c_str());
 
@@ -1133,6 +1137,7 @@ void CDnaStation::WriteGeoidfile(std::ofstream* geo_ofstream)
 void CDnaStation::SetStationRec(const station_t& stationRecord)
 {
 	SetName(stationRecord.stationName);
+	SetOriginalName(stationRecord.stationNameOrig);
 	SetConstraints(stationRecord.stationConst);
 	SetCoordType(stationRecord.stationType);
 	

--- a/dynadjust/include/measurement_types/dnastation.hpp
+++ b/dynadjust/include/measurement_types/dnastation.hpp
@@ -171,6 +171,7 @@ public:
 	
 	inline int CompareStationName(const string& s) { return m_strName.compare(s); }
 	inline string GetName() const { return m_strName; }
+	inline string GetOriginalName() const { return m_strOriginalName; }
 	inline string GetConstraints() const { return m_strConstraints; }
 	inline string GetCoordType() const { return m_strType; }
 
@@ -232,6 +233,8 @@ public:
 	inline void SetcurrentHeight_d(const double& dHeight) { m_dcurrentHeight = dHeight; }
 	
 	inline void SetName(const string& sName) { m_strName = trimstr(sName); }
+	inline void SetOriginalName(const string& sName) { m_strOriginalName = trimstr(sName); }
+	inline void SetOriginalName() { m_strOriginalName = m_strName; }
 	void SetHemisphereZone(const string& sHemisphereZone);
 	inline void SetDescription(const string& sDescription) { m_strDescription = trimstr(sDescription); }
 	inline void SetComment(const string& sComment) { m_strComment = trimstr(sComment); }
@@ -307,6 +310,8 @@ public:
 	string m_strName;
 
 protected:
+
+	string m_strOriginalName;
 
 	double m_dXAxis;
 	double m_dYAxis;


### PR DESCRIPTION
## Overview

This pull request closes #15 and fixes a minor defect in the renaming of discontinuity sites:

### import
- **Bug fix:** When discontinuity sites identified in non-SINEX files are found (c.f. #88), the convention is to rename the station and its appearance in all associated measurements as `<station-name>_yyyydoy`, where `doy` is a three digit string regardless of the day of year. This pull request fixes a defect relating to naming stations when the day of year of the measurement epoch is less than 10 and/or 100. For days of the year less than 10 and/or 100, **import** now correctly inserts the correct number of zeros into the new discontinuity site name as per the convention.  For example, the date `01.01.2010` is now correctly written as `<station-name>_2010001` (previous versions would have written this as `<station-name>_20101`). Note that this defect does not affect the way discontinuities are handled.

### adjust
- **Enhancement:** This enhancement closes #15. When specifying stations to constrain from the **adjust** command line, this enhancement takes renaming into account if a discontinuity file was introduced by **import**. For example, if the option and argument `--constraints "ALIC,CCC"` is provided to **adjust** and `ALIC` is a known discontinuity site, the station and its constraint will be interpreted on the fly as `ALIC_yyydoy,CCC`. This enables the static referencing of discontinuity sites by their primary name irrespective of new events or date changes relating to that site in the discontinuities file.

### All applications
- **Warning:** To deliver this enhancement, a new field (`stationNameOrig`) has been added to the binary station file struct (see [here](https://github.com/rogerfraser/DynAdjust/blob/master/dynadjust/include/config/dnatypes.hpp#L549)). This affects all DynAdjust applications. The practical implication of this change for *all users* is that binary station files (`*.bst`) created by previous versions of **import** cannot be read by this or future versions of **geoid**, **reftran**, **segment**, **adjust** or **plot**, and will need to be recreated by **import**.




