### PR TITLE
Fix boost.process for Boost 1.88+

### DIFF
--- a/dynadjust/dynadjust/dnaadjust/precompile.h
+++ b/dynadjust/dynadjust/dnaadjust/precompile.h
@@ -7,7 +7,6 @@
 
 // See https://github.com/boostorg/process/issues/161
 #define _WIN32_WINNT 0x0501
-#include <boost/process.hpp>
 
 // Support MKL inverse oly if compiler is Intel
 #if defined(__ICC) || defined(__INTEL_COMPILER)		// Intel compiler

--- a/dynadjust/dynadjust/dnaadjustwrapper/precompile.h
+++ b/dynadjust/dynadjust/dnaadjustwrapper/precompile.h
@@ -7,7 +7,6 @@
 
 // See https://github.com/boostorg/process/issues/161
 #define _WIN32_WINNT 0x0501
-#include <boost/process.hpp>
 
 #include <include/config/dnaversion.hpp>
 #include <include/config/dnaversion-stream.hpp>

--- a/dynadjust/dynadjust/dnaplot/precompile.h
+++ b/dynadjust/dynadjust/dnaplot/precompile.h
@@ -7,7 +7,6 @@
 
 // See https://github.com/boostorg/process/issues/161
 #define _WIN32_WINNT 0x0501
-#include <boost/process.hpp>
 
 #if defined(_WIN32) || defined(__WIN32__)
 #define BOOST_USE_WINDOWS_H

--- a/dynadjust/dynadjust/dnaplotwrapper/precompile.h
+++ b/dynadjust/dynadjust/dnaplotwrapper/precompile.h
@@ -7,7 +7,6 @@
 
 // See https://github.com/boostorg/process/issues/161
 #define _WIN32_WINNT 0x0501
-#include <boost/process.hpp>
 
 #if defined(_WIN32) || defined(__WIN32__)
 #define BOOST_USE_WINDOWS_H

--- a/dynadjust/dynadjust/dynadjust/precompile.h
+++ b/dynadjust/dynadjust/dynadjust/precompile.h
@@ -7,7 +7,6 @@
 
 // See https://github.com/boostorg/process/issues/161
 #define _WIN32_WINNT 0x0501
-#include <boost/process.hpp>
 
 #include <include/config/dnaversion.hpp>
 #include <include/config/dnaconsts.hpp>

--- a/dynadjust/include/functions/dnaprocessfuncs.cpp
+++ b/dynadjust/include/functions/dnaprocessfuncs.cpp
@@ -5,81 +5,89 @@
 // Version      : 1.00
 // Copyright    : Copyright 2017 Geoscience Australia
 //
-//                Licensed under the Apache License, Version 2.0 (the "License");
-//                you may not use this file except in compliance with the License.
-//                You may obtain a copy of the License at
-//               
+//                Licensed under the Apache License, Version 2.0 (the
+//                "License"); you may not use this file except in compliance
+//                with the License. You may obtain a copy of the License at
+//
 //                http ://www.apache.org/licenses/LICENSE-2.0
-//               
-//                Unless required by applicable law or agreed to in writing, software
-//                distributed under the License is distributed on an "AS IS" BASIS,
-//                WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//                See the License for the specific language governing permissions and
-//                limitations under the License.
+//
+//                Unless required by applicable law or agreed to in writing,
+//                software distributed under the License is distributed on an
+//                "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//                either express or implied. See the License for the specific
+//                language governing permissions and limitations under the
+//                License.
 //
 // Description  : Common process and fork functions
 //============================================================================
 
 #include <include/functions/dnaprocessfuncs.hpp>
 #include <iostream>
+#if BOOST_VERSION >= 108800
+// 1.88 or newer – pull in the v1 interface manually
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/start_dir.hpp>
+#include <boost/process/v1/system.hpp>
+namespace bp = boost::process::v1;
+#else
+// pre-1.88
 #include <boost/process.hpp>
+namespace bp = boost::process;
+#endif
 
-bool run_command(const std::string& executable_path, const UINT16& quiet)
-{	
-	// use boost's platform independent code to invoke a process
-	// see https://www.boost.org/doc/libs/develop/doc/html/process.html
-	//
-	// An exit code of zero means the process was successful, 
-	// while one different than zero indicates an error.
+bool run_command(const std::string& executable_path, const UINT16& quiet) {
+    // use boost's platform independent code to invoke a process
+    // see https://www.boost.org/doc/libs/develop/doc/html/process.html
+    //
+    // An exit code of zero means the process was successful,
+    // while one different than zero indicates an error.
 
-	
-	// For windows batch files, add cmd to execute the batch file.
+    // For windows batch files, add cmd to execute the batch file.
 #if defined(_WIN32) || defined(__WIN32__)
 
-	STARTUPINFO startup;
-	PROCESS_INFORMATION process;
+    STARTUPINFO startup;
+    PROCESS_INFORMATION process;
 
-	memset(&startup, 0, sizeof(STARTUPINFO));
-	memset(&process, 0, sizeof(PROCESS_INFORMATION));
+    memset(&startup, 0, sizeof(STARTUPINFO));
+    memset(&process, 0, sizeof(PROCESS_INFORMATION));
 
-	startup.cb = sizeof(STARTUPINFO);
+    startup.cb = sizeof(STARTUPINFO);
 
-	DWORD return_code(EXIT_SUCCESS);
-	if (CreateProcess(0, (LPSTR)executable_path.c_str(), 0, 0, FALSE,
-		0, 0, 0, &startup, &process))
-	{
-		WaitForSingleObject(process.hProcess, INFINITE);
-		// Capture the return code
-		GetExitCodeProcess(process.hProcess, &return_code);
-		CloseHandle(process.hThread);
-		CloseHandle(process.hProcess);
+    DWORD return_code(EXIT_SUCCESS);
+    if (CreateProcess(0, (LPSTR)executable_path.c_str(), 0, 0, FALSE, 0, 0, 0,
+                      &startup, &process)) {
+        WaitForSingleObject(process.hProcess, INFINITE);
+        // Capture the return code
+        GetExitCodeProcess(process.hProcess, &return_code);
+        CloseHandle(process.hThread);
+        CloseHandle(process.hProcess);
 
-		return (return_code == EXIT_SUCCESS);
-	}
-	return EXIT_SUCCESS;
+        return (return_code == EXIT_SUCCESS);
+    }
+    return EXIT_SUCCESS;
 
-#elif defined(__linux) || defined(sun) || defined(__unix__) || defined(__APPLE__)		
+#elif defined(__linux) || defined(sun) || defined(__unix__) ||                 \
+    defined(__APPLE__)
 
-	int return_value(0);
+    int return_value(0);
 
-	try {	
-		if (quiet)
-			return_value = boost::process::system(executable_path, boost::process::std_out > boost::process::null);
-		else
-			return_value = boost::process::system(executable_path, boost::process::std_out > stdout);
-		}
-	catch (const boost::process::process_error& e)
-	{
-		std::cout << std::endl << "- Error: Cannot find " << executable_path << "\n" <<
-			"  " << e.what() << std::endl;
-		return EXIT_FAILURE;
-	}
+    try {
+        if (quiet)
+            return_value = bp::system(executable_path, bp::std_out > bp::null);
+        else
+            return_value = bp::system(executable_path, bp::std_out > stdout);
+    } catch (const bp::process_error& e) {
+        std::cout << std::endl
+                  << "- Error: Cannot find " << executable_path << "\n"
+                  << "  " << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
 
-	return (return_value == EXIT_SUCCESS);
+    return (return_value == EXIT_SUCCESS);
 
 #endif
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }
-
-


### PR DESCRIPTION
Boost 1.88 broke the code... see:

https://github.com/boostorg/process/issues/480

The changes handle Boost Process version compatibility by:
  - Using the v1 interface headers directly when using Boost 1.88 or newer
  - Falling back to the traditional include for older Boost versions