### PR TITLE
Fix schema location bug

### DIFF
--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -260,7 +260,7 @@ include_directories(${XSD_INCLUDE_DIR} ${XSD_INCLUDE_DIR}/xsd)
 set(Boost_NO_BOOST_CMAKE ON)
 set(Boost_NO_CMAKE ON)
 find_package(Boost REQUIRED
-    COMPONENTS program_options)
+    COMPONENTS program_options filesystem)
 message(STATUS "Found Boost version: ${Boost_VERSION}")
 
 # ----------------------------------------------------------------------------

--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -260,7 +260,7 @@ include_directories(${XSD_INCLUDE_DIR} ${XSD_INCLUDE_DIR}/xsd)
 set(Boost_NO_BOOST_CMAKE ON)
 set(Boost_NO_CMAKE ON)
 find_package(Boost REQUIRED
-    COMPONENTS program_options filesystem)
+    COMPONENTS program_options)
 message(STATUS "Found Boost version: ${Boost_VERSION}")
 
 # ----------------------------------------------------------------------------

--- a/dynadjust/CMakeLists.txt
+++ b/dynadjust/CMakeLists.txt
@@ -273,6 +273,22 @@ set(DNA_LIBRARIES
 )
 
 # ----------------------------------------------------------------------------
+# C++ filesystem library
+# ----------------------------------------------------------------------------
+
+# Link C++ filesystem library if needed
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+        list(APPEND DNA_LIBRARIES stdc++fs)
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Only needed on Linux with Clang (not on macOS/Apple Clang)
+    if(UNIX AND NOT APPLE)
+        list(APPEND DNA_LIBRARIES stdc++fs)
+    endif()
+endif()
+
+# ----------------------------------------------------------------------------
 # OpenMP
 # ----------------------------------------------------------------------------
 

--- a/dynadjust/dynadjust/dnaadjustwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnaadjustwrapper/CMakeLists.txt
@@ -19,6 +19,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnaadjust ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${DNA_PROGRAM_PREFIX}adjust")
 endif()
 

--- a/dynadjust/dynadjust/dnadiff/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnadiff/CMakeLists.txt
@@ -12,6 +12,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
 else()
   SET (STATIC_TARGET_NAME "${PROJECT_NAME}_static")
 

--- a/dynadjust/dynadjust/dnadiff/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnadiff/CMakeLists.txt
@@ -13,8 +13,13 @@ if(NOT BUILD_STATIC)
   target_link_libraries (${PROJECT_NAME})
 
   # Link C++ filesystem library if needed
-  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Only needed on Linux with Clang (not on macOS/Apple Clang)
+    if(UNIX AND NOT APPLE)
       target_link_libraries (${PROJECT_NAME} stdc++fs)
     endif()
   endif()
@@ -27,6 +32,18 @@ else()
 
   # Always output as 'dnadiff' (not 'dnadiff_static')
   SET_TARGET_PROPERTIES(${STATIC_TARGET_NAME} PROPERTIES OUTPUT_NAME dnadiff)
+
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${STATIC_TARGET_NAME} stdc++fs)
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Only needed on Linux with Clang (not on macOS/Apple Clang)
+    if(UNIX AND NOT APPLE)
+      target_link_libraries (${STATIC_TARGET_NAME} stdc++fs)
+    endif()
+  endif()
 
   # Link statically
   if(UNIX)

--- a/dynadjust/dynadjust/dnageoidwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnageoidwrapper/CMakeLists.txt
@@ -18,6 +18,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnageoid ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${DNA_PROGRAM_PREFIX}geoid")
 endif()
 

--- a/dynadjust/dynadjust/dnaimport/dnainterop.hpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.hpp
@@ -189,10 +189,12 @@ public:
 	void ParseDiscontinuities(const std::string& fileName);
 
 private:
-	
+
 	// DynaML files
-	void ParseXML(const std::string& fileName, vdnaStnPtr* vStations, PUINT32 stnCount, 
-							   vdnaMsrPtr* vMeasurements, PUINT32 msrCount, PUINT32 clusterID, 
+	bool CheckAndWarnInvalidSchemaLocation(const std::string& fileName);
+
+	void ParseXML(const std::string& fileName, vdnaStnPtr* vStations, PUINT32 stnCount,
+							   vdnaMsrPtr* vMeasurements, PUINT32 msrCount, PUINT32 clusterID,
 							   std::string& fileEpsg, std::string& fileEpoch, bool firstFile, std::string* success_msg);
 	
 	// SINEX files

--- a/dynadjust/dynadjust/dnaimportwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnaimportwrapper/CMakeLists.txt
@@ -19,6 +19,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnaimport ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES
                          OUTPUT_NAME "${DNA_PROGRAM_PREFIX}import")
 endif()

--- a/dynadjust/dynadjust/dnaplotwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnaplotwrapper/CMakeLists.txt
@@ -17,6 +17,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnaplot ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${DNA_PROGRAM_PREFIX}plot")
 endif()
 

--- a/dynadjust/dynadjust/dnareftranwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnareftranwrapper/CMakeLists.txt
@@ -18,6 +18,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnareftran ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES
                          OUTPUT_NAME "${DNA_PROGRAM_PREFIX}reftran")
 endif()

--- a/dynadjust/dynadjust/dnasegmentwrapper/CMakeLists.txt
+++ b/dynadjust/dynadjust/dnasegmentwrapper/CMakeLists.txt
@@ -19,6 +19,13 @@ if(NOT BUILD_STATIC)
 
   target_link_libraries (${PROJECT_NAME} dnasegment ${DNA_LIBRARIES})
 
+  # Link C++ filesystem library if needed
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+      target_link_libraries (${PROJECT_NAME} stdc++fs)
+    endif()
+  endif()
+
   set_target_properties (${PROJECT_NAME} PROPERTIES
                          OUTPUT_NAME "${DNA_PROGRAM_PREFIX}segment")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,18 @@ else()
     set(PLATFORM_LIBS "")
 endif()
 
+# C++ filesystem library for C++17
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.0")
+        list(APPEND PLATFORM_LIBS stdc++fs)
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Only needed on Linux with Clang (not on macOS/Apple Clang)
+    if(UNIX AND NOT APPLE)
+        list(APPEND PLATFORM_LIBS stdc++fs)
+    endif()
+endif()
+
 # Common source files for I/O tests
 set(IO_COMMON_SOURCES
     ../dynadjust/include/io/dynadjust_file.cpp


### PR DESCRIPTION
When an XML file with data has a hardcoded schema location like:
```
<?xml version="1.0"?>
<DnaXmlFormat type="Measurement File" referenceframe="GDA2020" epoch="01.01.2020" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="C:\DynAdjust\exe\DynaML.xsd">
  <!-- Type D Direction set -->
```

Fix the problem whereby `dnaimport` can hang because it can't find that file. Now it checks if it can use `DynaML.xsd` from the current directory, otherwise fail with an error.