### PR TITLE
Matrix inversion and statistics fixes (issue #228)

### DIFF
--- a/dynadjust/dynadjust/dnaadjust/dnaadjust-multi.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust-multi.cpp
@@ -303,7 +303,7 @@ void dna_adjust::SolveMT(bool COMPUTE_INVERSE, const UINT32& block)
 	{
 		// Compute inverse of normals (aposteriori variance matrix)
 		// (AT * V-1 * A)-1
-		FormInverseVarianceMatrix(&(v_normalsR_.at(block)));
+		FormInverseVarianceMatrix(&(v_normalsR_.at(block)), false);
 	}
 
 	// compute weighted "measured minus computed"

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -568,6 +568,7 @@ void dna_adjust::UpdateAdjustment(bool iterate)
 		ss << "UpdateAdjustment(): Process terminated while allocating memory for the " << std::endl << "  adjustment matrices. " <<
 			"Details: " << std::endl << "  " << e.what() << std::endl;
 		adj_file << "- Error:" << std::endl << "  " << ss.str();
+		adj_file.flush();
 		SignalExceptionAdjustment(ss.str(), block);
 	}
 	catch (const std::runtime_error& e) {
@@ -575,8 +576,24 @@ void dna_adjust::UpdateAdjustment(bool iterate)
 		ss << "UpdateAdjustment(): Process terminated while updating the " << std::endl << "  adjustment matrices. " <<
 			"Details: " << std::endl << "  " << e.what() << std::endl;
 		adj_file << "- Error:" << std::endl << "  " << ss.str();
+		adj_file.flush();
 		SignalExceptionAdjustment(ss.str(), block);
 	}		
+	catch (const std::exception& e) {
+		std::stringstream ss;
+		ss << "UpdateAdjustment(): Unexpected exception at block " << block + 1 << "." << std::endl
+			<< "  Details: " << e.what() << std::endl;
+		adj_file << "- Error:" << std::endl << "  " << ss.str();
+		adj_file.flush();
+		SignalExceptionAdjustment(ss.str(), block);
+	}
+	catch (...) {
+		std::stringstream ss;
+		ss << "UpdateAdjustment(): Unknown exception at block " << block + 1 << "." << std::endl;
+		adj_file << "- Error:" << std::endl << "  " << ss.str();
+		adj_file.flush();
+		SignalExceptionAdjustment(ss.str(), block);
+	}
 	
 	isPreparing_ = false;
 }
@@ -2446,7 +2463,10 @@ void dna_adjust::AdjustSimultaneous()
 				false, !v_msrTally_.at(0).ContainsNonGPS(), !v_msrTally_.at(0).ContainsNonGPS(), true, false);
 
 		// Update normals and measured-computed matrices for the next iteration.
-		UpdateAdjustment(iterate);
+		// On the last iteration, pass false to preserve the inverted normals
+		// needed for computing statistics (precision of adjusted measurements).
+		bool lastIteration = (i + 1 >= projectSettings_.a.max_iterations);
+		UpdateAdjustment(!lastIteration);
 	}
 
 	ValidateandFinaliseAdjustment(tot_time);
@@ -5268,7 +5288,7 @@ void dna_adjust::UpdateDesignNormalMeasMatrices_G(pit_vmsr_t _it_msr, UINT32& de
 		AtVinv->replace(stn1, design_row_begin, var_cart * -1);
 		AtVinv->replace(stn2, design_row_begin, var_cart);
 
-		if (!projectSettings_.a.stage)
+		if (buildnewMatrices && !projectSettings_.a.stage)
 			// Add weighted measurement contributions to normal matrix
 			UpdateNormals_G(stn1, stn2, design_row_begin, normals, AtVinv);
 	}
@@ -6044,7 +6064,7 @@ void dna_adjust::UpdateDesignNormalMeasMatrices_X(pit_vmsr_t _it_msr, UINT32& de
 			_it_msr_temp += 3;
 	}
 
-	if (projectSettings_.a.stage)
+	if (projectSettings_.a.stage || !buildnewMatrices)
 		return;
 	
 	_it_msr_temp = _it_msr_first;
@@ -6400,7 +6420,7 @@ void dna_adjust::UpdateDesignNormalMeasMatrices_Y(pit_vmsr_t _it_msr, UINT32& de
 		design_row_begin += 3;
 	}
 
-	if (projectSettings_.a.stage)
+	if (projectSettings_.a.stage || !buildnewMatrices)
 		return;
 	
 	_it_msr_temp = _it_msr_first;

--- a/dynadjust/include/math/dnamatrix_contiguous.hpp
+++ b/dynadjust/include/math/dnamatrix_contiguous.hpp
@@ -165,12 +165,10 @@ static_assert(sizeof(lapack_int) == 4, "LP64 interface requires 32-bit integers"
 extern "C" {
 void LAPACK_FUNC(dpotrf)(const char* uplo, const lapack_int* n, double* a, const lapack_int* lda, lapack_int* info);
 void LAPACK_FUNC(dpotri)(const char* uplo, const lapack_int* n, double* a, const lapack_int* lda, lapack_int* info);
-void LAPACK_FUNC(dsyevr)(const char* jobz, const char* range, const char* uplo, const lapack_int* n, 
-                        double* a, const lapack_int* lda, const double* vl, const double* vu,
-                        const lapack_int* il, const lapack_int* iu, const double* abstol,
-                        lapack_int* m, double* w, double* z, const lapack_int* ldz,
-                        lapack_int* isuppz, double* work, const lapack_int* lwork,
-                        lapack_int* iwork, const lapack_int* liwork, lapack_int* info);
+void LAPACK_FUNC(dsytrf)(const char* uplo, const lapack_int* n, double* a, const lapack_int* lda,
+                         lapack_int* ipiv, double* work, const lapack_int* lwork, lapack_int* info);
+void LAPACK_FUNC(dsytri)(const char* uplo, const lapack_int* n, double* a, const lapack_int* lda,
+                         const lapack_int* ipiv, double* work, lapack_int* info);
 void BLAS_FUNC(dgemm)(const enum CBLAS_ORDER ORDER, const enum CBLAS_TRANSPOSE TRANSA,
                       const enum CBLAS_TRANSPOSE TRANSB, const lapack_int M, const lapack_int N, const lapack_int K,
                       const double ALPHA, const double* A, const lapack_int LDA, const double* B, const lapack_int LDB,
@@ -184,11 +182,10 @@ using namespace dynadjust::exception;
 namespace dynadjust {
 namespace math {
 
-// Debug flags
-#ifndef DEBUG_MATRIX_2D
-#define DEBUG_MATRIX_2D 0
-#endif
-
+class MatrixInversionFailure : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
 
 class matrix_2d;
 typedef std::vector<matrix_2d> v_mat_2d, *pv_mat_2d;
@@ -341,7 +338,7 @@ class matrix_2d : public new_handler_support<matrix_2d> {
         return true;
     }
 
-    matrix_2d operator=(const matrix_2d& rhs);
+    matrix_2d& operator=(const matrix_2d& rhs);
     matrix_2d operator*(const double& rhs) const;
     //
     // Initialisation / manipulation


### PR DESCRIPTION
Fixes bugs in matrix code (copybuffer(), operator=, and cholesky_inverse()), cleans up the debugging code (hopefully we don't need this anymore), and now calculates/prints statistics properly when dnaadjust doesn't converge but maybe gets close. It should now show the correct number of outliers, for example.

These very subtle bugs in the matrix code were found with some extensive "fuzzing" on the supercomputer.

So more works towards fixing issue #228 ...

The normal equations matrix N = A^T V^{-1} A is mathematically guaranteed to be positive semi-definite by construction *when the network is properly constrained*. The MatrixInversionFailure exception is really there now for the measurement VCV inversions, where the input data can legitimately produce singular or near-singular matrices. This is due to bad data.

For example, with the "Coffs Harbour" dataset (adjustment of directions and distances extracted from many Deposited Plans (DPs) across Coffs Harbour), when now running with these  measurement ids enabled:

 - 102001007 (type D, line 1904)
 - 102001009 (type D, line 1912)
 - 103001007 (type E, line 1919)
 
Then we should expect to get a MatrixInversionFailure because this gives singular matrices, i.e., bad data. Not much we can do about this.

The secondary issue with this dataset is that when those measurements above are disabled then the solution oscillates between two solutions, I've been working on this too. Fix coming...