### PR TITLE
Add iteration times

### DIFF
--- a/dynadjust/dynadjust/dnaadjust/dnaadjust-multi.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust-multi.cpp
@@ -94,11 +94,9 @@ void dna_adjust::AdjustPhasedMultiThread()
 	initialiseIteration();
 
 	std::string corr_msg;
-	std::ostringstream ss;
 	UINT32 i;
 	bool iterate(true);
 
-	std::chrono::milliseconds iteration_time(std::chrono::milliseconds(0));
 	cpu_timer it_time, tot_time;
 
 #if defined(__ICC) || defined(__INTEL_COMPILER)		// Intel compiler
@@ -169,7 +167,6 @@ void dna_adjust::AdjustPhasedMultiThread()
 		for_each(mt_adjust_threads.begin(), mt_adjust_threads.end(), std::mem_fn(&std::thread::join));
 #endif
 		// This point is reached when the threads have finished
-		iteration_time = std::chrono::duration_cast<std::chrono::milliseconds>(it_time.elapsed().wall);
 
 		//delete mt_adjust_threads;
 #if defined(__ICC) || defined(__INTEL_COMPILER)		// Intel compiler
@@ -195,18 +192,12 @@ void dna_adjust::AdjustPhasedMultiThread()
 		if (IsCancelled())
 			break;
 
-		ss.str("");
-		if (iteration_time >= std::chrono::seconds(1)) {
-			auto seconds = std::chrono::duration_cast<std::chrono::seconds>(iteration_time);
-			ss << seconds.count() << "s";
-		} else {
-			ss << iteration_time.count() << "ms";
-		}
+		std::string iteration_time_str = format_wall_time(it_time.elapsed().wall);
 
 		///////////////////////////////////
 		// protected write to adj file (not needed here since write to
 		// adj file at this stage is via single thread
-		adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Elapsed time" << ss.str() << std::endl;
+		adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Elapsed time" << iteration_time_str << std::endl;
 		OutputLargestCorrection(corr_msg);
 		///////////////////////////////////
 
@@ -214,6 +205,7 @@ void dna_adjust::AdjustPhasedMultiThread()
 			debug_file << concurrentAdjustments.print_adjusted_blocks();
 
 		iterationCorrections_.add_message(corr_msg);
+		iterationTimes_.add_message(iteration_time_str);
 		iterationQueue_.push_and_notify(CurrentIteration());				// currentIteration begins at 1, so not zero-indexed
 
 		// continue iterating?

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.cpp
@@ -2112,6 +2112,7 @@ _ADJUST_STATUS_ dna_adjust::AdjustNetwork()
 	isIterationComplete_ = false;
 	isAdjustmentQuestionable_ = false;
 	iterationCorrections_.clear_messages();
+	iterationTimes_.clear_messages();
 
 	if (projectSettings_.o._database_ids)
 		LoadDatabaseId();
@@ -2432,6 +2433,7 @@ void dna_adjust::AdjustSimultaneous()
 
 		// update data for messages
 		iterationCorrections_.add_message(corr_msg);
+		iterationTimes_.add_message(format_wall_time(it_time.elapsed().wall));
 		iterationQueue_.push_and_notify(CurrentIteration());	// currentIteration begins at 1, so not zero-indexed
 		isIterationComplete_ = true;
 		
@@ -2567,8 +2569,9 @@ void dna_adjust::AdjustPhased()
 
 		// Calculate and print largest adjustment correction and station ID
 		OutputLargestCorrection(corr_msg);
-		
+
 		iterationCorrections_.add_message(corr_msg);
+		iterationTimes_.add_message(format_wall_time(it_time.elapsed().wall));
 		iterationQueue_.push_and_notify(CurrentIteration());	// currentIteration begins at 1, so not zero-indexed
 		isIterationComplete_ = true;
 
@@ -2645,8 +2648,9 @@ void dna_adjust::AdjustPhasedBlock1()
 
 	if (fabs(maxCorr_) > projectSettings_.a.iteration_threshold)
 		adjustStatus_ = ADJUST_THRESHOLD_EXCEEDED;
-		
+
 	iterationCorrections_.add_message(corr_msg);
+	iterationTimes_.add_message(format_wall_time(it_time.elapsed().wall));
 	iterationQueue_.push_and_notify(CurrentIteration());	// currentIteration begins at 1, so not zero-indexed
 
 	ValidateandFinaliseAdjustment(tot_time);

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust.hpp
@@ -102,6 +102,7 @@ namespace networkadjust {
 extern std::mutex maxCorrMutex;
 
 using dynadjust::cpu_timer;
+using dynadjust::format_wall_time;
 
 // forward declaration of dna_adjust
 class dna_adjust;
@@ -349,6 +350,12 @@ class dna_adjust {
         if (iteration == 0)
             return iterationCorrections_.get_message(iteration); // safe guard
         return iterationCorrections_.get_message(iteration - 1);
+    };
+
+    inline std::string GetIterationTime(const UINT32& iteration) const {
+        if (iteration == 0)
+            return iterationTimes_.get_message(iteration); // safe guard
+        return iterationTimes_.get_message(iteration - 1);
     };
     /////////////////////////////
 
@@ -1118,6 +1125,7 @@ class dna_adjust {
     bool allStationsFixed_;
 
     message_bank<std::string> iterationCorrections_;
+    message_bank<std::string> iterationTimes_;
 
     // For each block
     vUINT32 v_ContiguousNetList_; // vector of contiguous network IDs

--- a/dynadjust/dynadjust/dnaadjust/dnaadjust_printer.cpp
+++ b/dynadjust/dynadjust/dnaadjust/dnaadjust_printer.cpp
@@ -80,22 +80,13 @@ void DynAdjustPrinter::PrintIteration(const UINT32& iteration) {
 }
 
 void DynAdjustPrinter::PrintAdjustmentTime(cpu_timer& time, int timer_type) {
-    // calculate and print total time
-    auto elapsed = time.elapsed();
-    double seconds = elapsed.wall.count() / 1.0e9;
-    
-    std::stringstream ss;
-    if (seconds >= 1.0) {
-        ss << std::fixed << std::setprecision(3) << seconds << "s";
-    } else {
-        ss << std::fixed << std::setprecision(3) << (seconds * 1000.0) << "ms";
-    }
+    std::string time_str = format_wall_time(time.elapsed().wall);
 
     if (timer_type == 0) // iteration_time equivalent
-        adjust_.adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Elapsed time" << ss.str() << std::endl;
+        adjust_.adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Elapsed time" << time_str << std::endl;
     else
     {
-        adjust_.adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Total time" << ss.str() << std::endl << std::endl;
+        adjust_.adj_file << std::setw(PRINT_VAR_PAD) << std::left << "Total time" << time_str << std::endl << std::endl;
     }
 }
 

--- a/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustprogress.cpp
+++ b/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustprogress.cpp
@@ -323,13 +323,14 @@ void dna_adjust_progress_thread::processAdjustment()
 				ss.str("");
 				ss << "  Iteration " << std::right << std::setw(2) << std::fixed << std::setprecision(0) << currentIteration;
 				ss << ", max station corr: " << std::right << std::setw(PROGRESS_ADJ_BLOCK_12) <<
-					_dnaAdj->GetMaxCorrection(currentIteration) << std::endl;
-					
+					_dnaAdj->GetMaxCorrection(currentIteration);
+				ss << ", time: " << _dnaAdj->GetIterationTime(currentIteration) << std::endl;
+
 				coutMessage(ss.str());
 			}
 			std::this_thread::sleep_for(std::chrono::milliseconds(80));
 		}
-		
+
 		break;
 	case Phased_Block_1Mode:
 	case PhasedMode:
@@ -350,12 +351,13 @@ void dna_adjust_progress_thread::processAdjustment()
 						
 				ss.str("");
 				ss << "  Iteration " << std::right << std::setw(2) << std::fixed << std::setprecision(0) << currentIteration;
-				ss << ", max station corr: " << std::right << std::setw(PROGRESS_ADJ_BLOCK_12) << _dnaAdj->GetMaxCorrection(currentIteration) << std::endl;
-				
+				ss << ", max station corr: " << std::right << std::setw(PROGRESS_ADJ_BLOCK_12) << _dnaAdj->GetMaxCorrection(currentIteration);
+				ss << ", time: " << _dnaAdj->GetIterationTime(currentIteration) << std::endl;
+
 				sst.str("");
 				if (first_time)
 					sst << std::setw(PROGRESS_ADJ_BLOCK_28) << std::left << " ";
-				sst << PROGRESS_BACKSPACE_28 << std::setw(PROGRESS_ADJ_BLOCK_28) << std::left << ss.str();
+				sst << PROGRESS_BACKSPACE_28 << std::left << ss.str();
 				coutMessage(sst.str());
 				first_time = true;
 			}

--- a/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustwrapper.cpp
+++ b/dynadjust/dynadjust/dnaadjustwrapper/dnaadjustwrapper.cpp
@@ -86,8 +86,9 @@ void PrintSummaryMessage(dna_adjust* netAdjust, const project_settings* p, boost
 			break;
 		std::stringstream ss("");
 		ss << "  Iteration " << std::right << std::setw(2) << std::fixed << std::setprecision(0) << currentIteration;
-		ss << ", max station corr: " << std::right << std::setw(12) << netAdjust->GetMaxCorrection(currentIteration) << std::endl;
-		std::cout << PROGRESS_BACKSPACE_28 << std::setw(28) << std::left << ss.str();
+		ss << ", max station corr: " << std::right << std::setw(12) << netAdjust->GetMaxCorrection(currentIteration);
+		ss << ", time: " << netAdjust->GetIterationTime(currentIteration) << std::endl;
+		std::cout << PROGRESS_BACKSPACE_28 << std::left << ss.str();
 	}
 
 	if (p->a.report_mode)

--- a/dynadjust/include/functions/dnatimer.hpp
+++ b/dynadjust/include/functions/dnatimer.hpp
@@ -72,6 +72,16 @@ private:
     std::chrono::high_resolution_clock::time_point start_time_;
 };
 
+inline std::string format_wall_time(std::chrono::nanoseconds wall) {
+    double seconds = wall.count() / 1.0e9;
+    std::ostringstream oss;
+    if (seconds >= 1.0)
+        oss << std::fixed << std::setprecision(3) << seconds << "s";
+    else
+        oss << std::fixed << std::setprecision(3) << (seconds * 1000.0) << "ms";
+    return oss.str();
+}
+
 }  // namespace dynadjust
 
 #endif  // DNATIMER_H_


### PR DESCRIPTION
Adds iteration times to console output, which is useful for benchmarking when running very large adjustments.
```
   Iteration  1, max station corr:  -10.5554 up, time: 0.283ms
   Iteration  2, max station corr:   -0.0000 up, time: 0.076ms
```