### PR TITLE
Add support for epoch of observation #325

### DIFF
--- a/dynadjust/dynadjust/dnaimport/dnainterop.cpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.cpp
@@ -174,7 +174,8 @@ void dna_import::BuildExtractStationsList(const std::string& stnList, pvstring v
 }
 	
 
-void dna_import::InitialiseDatum(const std::string& reference_frame, const std::string epoch)
+void dna_import::InitialiseDatum(const std::string& reference_frame, const std::string epoch,
+	const std::string observation_epoch)
 {
 	try {
 		// Take the default reference frame, set either by the user or
@@ -196,11 +197,13 @@ void dna_import::InitialiseDatum(const std::string& reference_frame, const std::
 	if (datum_.GetEpoch() == timeImmemorial<boost::gregorian::date>())
 		m_strProjectDefaultEpoch = "";
 
+	m_strProjectObservationEpoch = observation_epoch;
+
 	// Update binary file meta
 	// Note: the following rule applies each time a set of files is loaded via import:
 	//	* This method (InitialiseDatum) is called (from dnaimportwrapper) before any files are loaded.
 	//    By default, the bst & bms meta are initialised with the reference frame and reference epoch.
-	//  * The datum and epoch within the first file (if present) is used to set the default project 
+	//  * The datum and epoch within the first file (if present) is used to set the default project
 	//    datum. If a datum isn't provided in the first input file, e.g. SINEX file, the default datum
 	//    (GDA2020) is used. As each subsequent file is loaded, the default frame and epoch are assumed.
 	//  * After all files have been loaded, InitialiseDatum is called again to set the metadata.
@@ -210,6 +213,56 @@ void dna_import::InitialiseDatum(const std::string& reference_frame, const std::
     snprintf(bms_meta_.epsgCode, sizeof(bms_meta_.epsgCode), "%s", m_strProjectDefaultEpsg.substr(0, STN_EPSG_WIDTH).c_str());
     snprintf(bst_meta_.epoch, sizeof(bst_meta_.epoch), "%s", m_strProjectDefaultEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
     snprintf(bms_meta_.epoch, sizeof(bms_meta_.epoch), "%s", m_strProjectDefaultEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
+    // observation_epoch is immutable; record the CLI-supplied project-level value (empty if not supplied).
+    snprintf(bst_meta_.observation_epoch, sizeof(bst_meta_.observation_epoch), "%s", m_strProjectObservationEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
+    snprintf(bms_meta_.observation_epoch, sizeof(bms_meta_.observation_epoch), "%s", m_strProjectObservationEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
+}
+
+
+void dna_import::ApplyProjectObservationEpoch(vdnaMsrPtr* vMeasurements)
+{
+	if (m_strProjectObservationEpoch.empty() || vMeasurements == nullptr)
+		return;
+
+	const std::string& obsEpoch = m_strProjectObservationEpoch;
+
+	// A measurement's observation_epoch is treated as "not explicitly set" when it is
+	// empty or equal to the reference-frame epoch (the auto-default from SetEpoch).
+	auto needs_override = [](const std::string& msrObsEpoch, const std::string& msrEpoch) {
+		return msrObsEpoch.empty() || msrObsEpoch == msrEpoch;
+	};
+
+	for (auto& msr_ptr : *vMeasurements)
+	{
+		if (!msr_ptr)
+			continue;
+
+		if (needs_override(msr_ptr->GetObservationEpoch(), msr_ptr->GetEpoch()))
+			msr_ptr->SetObservationEpoch(obsEpoch);
+
+		// GPS baseline cluster (G/X): propagate to every baseline element
+		if (auto* baselines = msr_ptr->GetBaselines_ptr())
+		{
+			for (auto& bsl : *baselines)
+			{
+				if (needs_override(bsl.GetObservationEpoch(), bsl.GetEpoch()))
+					bsl.SetObservationEpoch(obsEpoch);
+			}
+		}
+
+		// GPS point cluster (Y): propagate to every point element
+		if (auto* points = msr_ptr->GetPoints_ptr())
+		{
+			for (auto& pnt : *points)
+			{
+				if (needs_override(pnt.GetObservationEpoch(), pnt.GetEpoch()))
+					pnt.SetObservationEpoch(obsEpoch);
+			}
+		}
+
+		// Direction set (D): directions inherit from the parent measurement; no per-direction
+		// observation_epoch field exists beyond what the set-level value already carries.
+	}
 }
 	
 
@@ -436,7 +489,7 @@ void dna_import::ParseXML(const std::string& fileName, vdnaStnPtr* vStations, PU
 		StationCoord_p.parsers (string_p, string_p, string_p, Height_p, string_p, GeoidModel_p);
 
 		DnaMeasurement_p.parsers (string_p, string_p, string_p, string_p, string_p, string_p, string_p, string_p,
-				string_p, string_p, Directions_p, string_p, string_p, string_p, GPSBaseline_p, string_p, string_p,
+				string_p, string_p, Directions_p, string_p, string_p, string_p, string_p, GPSBaseline_p, string_p, string_p,
 				string_p, Clusterpoint_p, string_p, string_p, string_p, string_p,
 				(projectSettings_.i.prefer_single_x_as_g == TRUE ? true : false));
 
@@ -818,12 +871,16 @@ void dna_import::ApplyDiscontinuitiesMeasurements(vdnaMsrPtr* vMeasurements)
 			continue;
 		}
 
-		// Check if an epoch been provided with this measurement
-		if (_it_msr->get()->GetEpoch().empty())
+		// Prefer the observation epoch for discontinuity matching; fall back
+		// to reference-frame epoch if the file did not supply an observation epoch.
+		std::string match_epoch = _it_msr->get()->GetObservationEpoch();
+		if (match_epoch.empty())
+			match_epoch = _it_msr->get()->GetEpoch();
+		if (match_epoch.empty())
 			continue;
 
 		// Capture the epoch of the measurement
-		site_date = dateFromString<boost::gregorian::date>(_it_msr->get()->GetEpoch());
+		site_date = dateFromString<boost::gregorian::date>(match_epoch);
 
 		// 2. Handle 'first' station for every measurement type
 		stn1 = _it_msr->get()->GetFirst();
@@ -930,8 +987,15 @@ void dna_import::ApplyDiscontinuitiesMeasurements_GX(std::vector<CDnaGpsBaseline
 		_it_msr != vGpsBaselines->end();
 		_it_msr++)
 	{
+		// Prefer observation epoch; fall back to reference-frame epoch.
+		std::string match_epoch = _it_msr->GetObservationEpoch();
+		if (match_epoch.empty())
+			match_epoch = _it_msr->GetEpoch();
+		if (match_epoch.empty())
+			continue;
+
 		// Capture the start date of the site
-		site_date = dateFromString<boost::gregorian::date>(_it_msr->GetEpoch());
+		site_date = dateFromString<boost::gregorian::date>(match_epoch);
 
 		// Station 1
 		stn1 = _it_msr->GetFirst();
@@ -983,8 +1047,15 @@ void dna_import::ApplyDiscontinuitiesMeasurements_Y(std::vector<CDnaGpsPoint>* v
 		_it_msr != vGpsPoints->end();
 		_it_msr++)
 	{
+		// Prefer observation epoch; fall back to reference-frame epoch.
+		std::string match_epoch = _it_msr->GetObservationEpoch();
+		if (match_epoch.empty())
+			match_epoch = _it_msr->GetEpoch();
+		if (match_epoch.empty())
+			continue;
+
 		// Capture the start date of the site
-		site_date = dateFromString<boost::gregorian::date>(_it_msr->GetEpoch());
+		site_date = dateFromString<boost::gregorian::date>(match_epoch);
 
 		// Station 1
 		stn1 = _it_msr->GetFirst();
@@ -1148,7 +1219,7 @@ void dna_import::ParseDNA(const std::string& fileName, vdnaStnPtr* vStations, PU
 			projectSettings_.r.epoch = fileEpoch;
 			m_strProjectDefaultEpoch = fileEpoch;
 
-			InitialiseDatum(projectSettings_.i.reference_frame, projectSettings_.i.epoch);
+			InitialiseDatum(projectSettings_.i.reference_frame, projectSettings_.i.epoch, projectSettings_.i.observation_epoch);
 		}
 	}
 
@@ -1739,12 +1810,18 @@ void dna_import::ParseDNAMSRLinear(const std::string& sBuf, dnaMsrPtr& msr_ptr)
 
 	// Epoch
 	msr_ptr->SetEpoch(ParseEpochValue(sBuf, "ParseDNAMSRLinear"));
+	// Observation epoch (DNA v3.02 column, optional)
+	{
+		std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRLinear");
+		if (!obs_epoch.empty())
+			msr_ptr->SetObservationEpoch(obs_epoch);
+	}
 
 	// Capture msr_id and cluster_id (for database referencing)
 	ParseDatabaseIds(sBuf, "ParseDNAMSRLinear", msr_ptr->GetTypeC());
 	msr_ptr->SetDatabaseMap(m_msr_db_map);
 
-	// instrument and target heights only make sense for 
+	// instrument and target heights only make sense for
 	// slope distances, vertical angles and zenith distances
 	switch (msr_ptr->GetTypeC())
 	{
@@ -1806,6 +1883,12 @@ void dna_import::ParseDNAMSRCoordinate(const std::string& sBuf, dnaMsrPtr& msr_p
 
 	// Epoch
 	msr_ptr->SetEpoch(ParseEpochValue(sBuf, "ParseDNAMSRLinear"));
+	// Observation epoch (DNA v3.02 column, optional)
+	{
+		std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRCoordinate");
+		if (!obs_epoch.empty())
+			msr_ptr->SetObservationEpoch(obs_epoch);
+	}
 
 	// Capture msr_id and cluster_id (for database referencing), then set
 	// database id info
@@ -1821,6 +1904,7 @@ void dna_import::ParseDNAMSRGPSBaselines(std::string& sBuf, dnaMsrPtr& msr_ptr, 
 
 	bslTmp.SetReferenceFrame(msr_ptr->GetReferenceFrame());
 	bslTmp.SetEpoch(msr_ptr->GetEpoch());
+	bslTmp.SetObservationEpoch(msr_ptr->GetObservationEpoch());
 
 	// Measurement type
 	std::string tmp;
@@ -1943,10 +2027,18 @@ void dna_import::ParseDNAMSRGPSBaselines(std::string& sBuf, dnaMsrPtr& msr_ptr, 
 				// Set the baseline epoch
 				bslTmp.SetEpoch(tmp);
 			}
+
+			// Observation epoch (DNA v3.02 column, optional; overrides default)
+			std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRGPSBaselines");
+			if (!obs_epoch.empty())
+			{
+				msr_ptr->SetObservationEpoch(obs_epoch);
+				bslTmp.SetObservationEpoch(obs_epoch);
+			}
 		}
 		catch (std::runtime_error& e) {
 			std::stringstream ss;
-			ss << "ParseDNAMSRGPSBaselines(): Error parsing epoch:  " << 
+			ss << "ParseDNAMSRGPSBaselines(): Error parsing epoch:  " <<
 			 	std::endl << "    " << e.what();
 			SignalExceptionParseDNA(ss.str(), "", dml_.msr_gps_epoch);
 		}
@@ -2042,6 +2134,7 @@ void dna_import::ParseDNAMSRGPSPoints(std::string& sBuf, dnaMsrPtr& msr_ptr, boo
 
 	pntTmp.SetReferenceFrame(msr_ptr->GetReferenceFrame());
 	pntTmp.SetEpoch(msr_ptr->GetEpoch());
+	pntTmp.SetObservationEpoch(msr_ptr->GetObservationEpoch());
 
 	// Measurement type
 	std::string tmp;
@@ -2136,6 +2229,7 @@ void dna_import::ParseDNAMSRGPSPoints(std::string& sBuf, dnaMsrPtr& msr_ptr, boo
 		// Set the point frame
 		pntTmp.SetReferenceFrame(projectSettings_.i.reference_frame);
 		pntTmp.SetEpoch(msr_ptr->GetEpoch());
+		pntTmp.SetObservationEpoch(msr_ptr->GetObservationEpoch());
 	}
 	else //if (!projectSettings_.i.override_input_rfame)
 	{
@@ -2153,7 +2247,7 @@ void dna_import::ParseDNAMSRGPSPoints(std::string& sBuf, dnaMsrPtr& msr_ptr, boo
 		}
 		catch (std::runtime_error& e) {
 			std::stringstream ss;
-			ss << "ParseDNAMSRGPSPoints(): Error parsing reference frame:  " << std::endl << 
+			ss << "ParseDNAMSRGPSPoints(): Error parsing reference frame:  " << std::endl <<
 				"    " << e.what();
 			SignalExceptionParseDNA(ss.str(), "", dml_.msr_gps_reframe);
 		}
@@ -2179,10 +2273,18 @@ void dna_import::ParseDNAMSRGPSPoints(std::string& sBuf, dnaMsrPtr& msr_ptr, boo
 				// Set the point epoch
 				pntTmp.SetEpoch(tmp);
 			}
+
+			// Observation epoch (DNA v3.02 column, optional; overrides default)
+			std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRGPSPoints");
+			if (!obs_epoch.empty())
+			{
+				msr_ptr->SetObservationEpoch(obs_epoch);
+				pntTmp.SetObservationEpoch(obs_epoch);
+			}
 		}
 		catch (std::runtime_error& e) {
 			std::stringstream ss;
-			ss << "ParseDNAMSRGPSPoints(): Error parsing epoch:  " << std::endl << 
+			ss << "ParseDNAMSRGPSPoints(): Error parsing epoch:  " << std::endl <<
 				"    " << e.what();
 			SignalExceptionParseDNA(ss.str(), "", dml_.msr_gps_epoch);
 		}
@@ -2691,7 +2793,7 @@ std::string dna_import::ParseEpochValue(const std::string& sBuf, const std::stri
 {
 	if (sBuf.length() <= dml_.msr_gps_epoch)
 		return "";
-	
+
 	std::string epoch;
 	try {
 		if (sBuf.length() > static_cast<std::string::size_type>(dml_.msr_gps_epoch + dmw_.msr_gps_epoch))
@@ -2705,6 +2807,30 @@ std::string dna_import::ParseEpochValue(const std::string& sBuf, const std::stri
 	}
 
 	return epoch;
+}
+
+std::string dna_import::ParseObsEpochValue(const std::string& sBuf, const std::string& calling_function)
+{
+	// DNA v3.01 (and earlier) files don't have an observation-epoch column;
+	// in that case the field layout leaves msr_gps_obs_epoch at 0.
+	if (dml_.msr_gps_obs_epoch == 0 || dmw_.msr_gps_obs_epoch == 0)
+		return "";
+	if (sBuf.length() <= dml_.msr_gps_obs_epoch)
+		return "";
+
+	std::string obs_epoch;
+	try {
+		if (sBuf.length() > static_cast<std::string::size_type>(dml_.msr_gps_obs_epoch + dmw_.msr_gps_obs_epoch))
+			obs_epoch = trimstr(sBuf.substr(dml_.msr_gps_obs_epoch, dmw_.msr_gps_obs_epoch));
+		else
+			obs_epoch = trimstr(sBuf.substr(dml_.msr_gps_obs_epoch));
+	}
+	catch (...) {
+		SignalExceptionParseDNA(calling_function + "(): Could not extract observation epoch from the record:  ",
+			sBuf, dml_.msr_gps_obs_epoch);
+	}
+
+	return obs_epoch;
 }
 
 std::string dna_import::ParseGPSMsrValue(const std::string& sBuf, const std::string& element, const std::string& calling_function)
@@ -2770,6 +2896,12 @@ void dna_import::ParseDNAMSRAngular(const std::string& sBuf, dnaMsrPtr& msr_ptr)
 
 	// Epoch
 	msr_ptr->SetEpoch(ParseEpochValue(sBuf, "ParseDNAMSRAngular"));
+	// Observation epoch (DNA v3.02 column, optional)
+	{
+		std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRAngular");
+		if (!obs_epoch.empty())
+			msr_ptr->SetObservationEpoch(obs_epoch);
+	}
 
 	// Capture msr_id and cluster_id (for database referencing), then set
 	// database id info
@@ -2849,6 +2981,12 @@ UINT32 dna_import::ParseDNAMSRDirections(std::string& sBuf, dnaMsrPtr& msr_ptr, 
 
 		// Epoch
 		msr_ptr->SetEpoch(ParseEpochValue(sBuf, "ParseDNAMSRDirections"));
+		// Observation epoch (DNA v3.02 column, optional)
+		{
+			std::string obs_epoch = ParseObsEpochValue(sBuf, "ParseDNAMSRDirections");
+			if (!obs_epoch.empty())
+				msr_ptr->SetObservationEpoch(obs_epoch);
+		}
 
 		// Capture msr_id and cluster_id (for database referencing)
 		ParseDatabaseIds(sBuf, "ParseDNAMSRDirections", msr_ptr->GetTypeC());

--- a/dynadjust/dynadjust/dnaimport/dnainterop.hpp
+++ b/dynadjust/dynadjust/dnaimport/dnainterop.hpp
@@ -180,8 +180,16 @@ public:
 	inline void ResetFileOrder() const { g_fileOrder = 0; }
 	inline bool filespecifiedReferenceFrame() const { return _filespecifiedreferenceframe; }
 	inline bool filespecifiedEpoch() const { return _filespecifiedepoch; }
-	void InitialiseDatum(const std::string& reference_frame, const std::string epoch="");
-	
+	void InitialiseDatum(const std::string& reference_frame, const std::string epoch="",
+		const std::string observation_epoch="");
+
+	// Applies the project-level observation epoch (from --observation-epoch) to every
+	// measurement whose observation_epoch is empty or equal to its reference-frame epoch
+	// (i.e. was auto-defaulted). Explicit file-level values set via <EpochOfObservation>
+	// or DNA v3.02 column 25 that differ from epoch are preserved. No-op if the CLI flag
+	// was not supplied.
+	void ApplyProjectObservationEpoch(vdnaMsrPtr* vMeasurements);
+
 	void PrintMeasurementsToStations(std::string& m2s_file, MsrTally* parsemsrTally,
 		std::string& bst_file, std::string& bms_file, std::string& aml_file, pvASLPtr vAssocStnList);
 
@@ -236,6 +244,7 @@ private:
 	std::string ParseScaleHValue(const std::string& sBuf, const std::string& calling_function);
 	std::string ParseRefFrameValue(const std::string& sBuf, const std::string& calling_function);
 	std::string ParseEpochValue(const std::string& sBuf, const std::string& calling_function);
+	std::string ParseObsEpochValue(const std::string& sBuf, const std::string& calling_function);
 
 	void ParseDatabaseIds(const std::string& sBuf, const std::string& calling_function, const char msrType);
 	void ParseDatabaseClusterId(const std::string& sBuf, const std::string& calling_function);
@@ -338,6 +347,7 @@ private:
 
 	std::string		m_strProjectDefaultEpsg;
 	std::string		m_strProjectDefaultEpoch;
+	std::string		m_strProjectObservationEpoch;	// Project-level observation epoch from --observation-epoch (immutable; may be empty)
 	std::string		m_msrComments;
 
 	vvUINT32	v_ISL_;				// Inner stations

--- a/dynadjust/dynadjust/dnaimport/dnaparser_pimpl.cxx
+++ b/dynadjust/dynadjust/dnaimport/dnaparser_pimpl.cxx
@@ -593,6 +593,30 @@ void DnaMeasurement_pimpl::Epoch(const ::std::string& Epoch)
 	}
 }
 
+void DnaMeasurement_pimpl::EpochOfObservation(const ::std::string& EpochOfObservation)
+{
+	if (!_dnaCurrentMsr)
+		throw XMLInteropException("\"Type\" element must be the first element within \"DnaMeasurement\".", 0);
+
+	try
+	{
+		if (EpochOfObservation.empty())
+			return;
+
+		_dnaCurrentMsr->SetObservationEpoch(EpochOfObservation);
+	}
+	catch (const std::runtime_error& e) {
+		std::stringstream ss("");
+		ss << e.what();
+		ss << "    - Measurement type:    " << _dnaCurrentMsr->GetType() << std::endl <<
+			"    - From:                " << _dnaCurrentMsr->GetFirst() << std::endl <<
+			"    - To:                  " << _dnaCurrentMsr->GetTarget() << std::endl <<
+			"    - Reference frame:     " << _dnaCurrentMsr->GetReferenceFrame() << std::endl <<
+			"    - Epoch of observation: " << EpochOfObservation << std::endl;
+		throw XMLInteropException(ss.str(), 0);
+	}
+}
+
 void DnaMeasurement_pimpl::ReferenceFrame(const ::std::string& ReferenceFrame)
 {
 	if (!_dnaCurrentMsr)

--- a/dynadjust/dynadjust/dnaimport/dnaparser_pimpl.hxx
+++ b/dynadjust/dynadjust/dnaimport/dnaparser_pimpl.hxx
@@ -91,6 +91,7 @@ public:
 	virtual void Directions ();
 	virtual void Vscale (const ::std::string&);
 	virtual void Epoch (const ::std::string&);
+	virtual void EpochOfObservation (const ::std::string&);
 	virtual void ReferenceFrame (const ::std::string&);
 	virtual void GPSBaseline ();
 	virtual void Hscale (const ::std::string&);

--- a/dynadjust/dynadjust/dnaimport/dnaparser_pskel.cxx
+++ b/dynadjust/dynadjust/dnaimport/dnaparser_pskel.cxx
@@ -258,6 +258,11 @@ void DnaMeasurement_pskel::Epoch_parser (::xml_schema::string_pskel& p)
 	this->Epoch_parser_ = &p;
 }
 
+void DnaMeasurement_pskel::EpochOfObservation_parser (::xml_schema::string_pskel& p)
+{
+	this->EpochOfObservation_parser_ = &p;
+}
+
 void DnaMeasurement_pskel::GPSBaseline_parser (::GPSBaseline_pskel& p)
 {
 	this->GPSBaseline_parser_ = &p;
@@ -318,6 +323,7 @@ void DnaMeasurement_pskel::parsers (
 	::Directions_pskel& Directions,
 	::xml_schema::string_pskel& Vscale,
 	::xml_schema::string_pskel& Epoch,
+	::xml_schema::string_pskel& EpochOfObservation,
 	::xml_schema::string_pskel& ReferenceFrame,
 	::GPSBaseline_pskel& GPSBaseline,
 	::xml_schema::string_pskel& Hscale,
@@ -343,6 +349,7 @@ void DnaMeasurement_pskel::parsers (
 	this->Directions_parser_ = &Directions;
 	this->Vscale_parser_ = &Vscale;
 	this->Epoch_parser_ = &Epoch;
+	this->EpochOfObservation_parser_ = &EpochOfObservation;
 	this->ReferenceFrame_parser_ = &ReferenceFrame;
 	this->GPSBaseline_parser_ = &GPSBaseline;
 	this->Hscale_parser_ = &Hscale;
@@ -370,6 +377,7 @@ DnaMeasurement_pskel::DnaMeasurement_pskel ()
 	Directions_parser_ (0),
 	Vscale_parser_ (0),
 	Epoch_parser_ (0),
+	EpochOfObservation_parser_ (0),
 	ReferenceFrame_parser_ (0),
 	GPSBaseline_parser_ (0),
 	Hscale_parser_ (0),
@@ -1326,6 +1334,10 @@ void DnaMeasurement_pskel::Epoch (const ::std::string&)
 {
 }
 
+void DnaMeasurement_pskel::EpochOfObservation (const ::std::string&)
+{
+}
+
 void DnaMeasurement_pskel::ReferenceFrame (const ::std::string&)
 {
 }
@@ -1509,6 +1521,16 @@ bool DnaMeasurement_pskel::_start_element_impl (const ::xml_schema::ro_string& n
 
 		if (this->Epoch_parser_)
 			this->Epoch_parser_->pre ();
+
+		return true;
+	}
+
+	if (n == "EpochOfObservation" && ns.empty ())
+	{
+		this->::xml_schema::complex_content::context_.top ().parser_ = this->EpochOfObservation_parser_;
+
+		if (this->EpochOfObservation_parser_)
+			this->EpochOfObservation_parser_->pre ();
 
 		return true;
 	}
@@ -1733,6 +1755,14 @@ bool DnaMeasurement_pskel::_end_element_impl (const ::xml_schema::ro_string& ns,
 	{
 		if (this->Epoch_parser_)
 			this->Epoch (this->Epoch_parser_->post_string ());
+
+		return true;
+	}
+
+	if (n == "EpochOfObservation" && ns.empty ())
+	{
+		if (this->EpochOfObservation_parser_)
+			this->EpochOfObservation (this->EpochOfObservation_parser_->post_string ());
 
 		return true;
 	}

--- a/dynadjust/dynadjust/dnaimport/dnaparser_pskel.hxx
+++ b/dynadjust/dynadjust/dnaimport/dnaparser_pskel.hxx
@@ -467,6 +467,7 @@ public:
 	virtual void Directions ();
 	virtual void Vscale (const ::std::string&);
 	virtual void Epoch (const ::std::string&);
+	virtual void EpochOfObservation (const ::std::string&);
 	virtual void ReferenceFrame (const ::std::string&);
 	virtual void GPSBaseline ();
 	virtual void Hscale (const ::std::string&);
@@ -558,6 +559,7 @@ public:
 	void Directions_parser (::Directions_pskel&);
 	void Vscale_parser (::xml_schema::string_pskel&);
 	void Epoch_parser (::xml_schema::string_pskel&);
+	void EpochOfObservation_parser (::xml_schema::string_pskel&);
 	void ReferenceFrame_parser (::xml_schema::string_pskel&);
 	void GPSBaseline_parser (::GPSBaseline_pskel&);
 	void Hscale_parser (::xml_schema::string_pskel&);
@@ -583,6 +585,7 @@ public:
 			::Directions_pskel& /* Directions */,
 			::xml_schema::string_pskel& /* Vscale */,
 			::xml_schema::string_pskel& /* Epoch */,
+			::xml_schema::string_pskel& /* EpochOfObservation */,
 			::xml_schema::string_pskel& /* ReferenceFrame */,
 			::GPSBaseline_pskel& /* GPSBaseline */,
 			::xml_schema::string_pskel& /* Hscale */,
@@ -630,6 +633,7 @@ protected:
 	::Directions_pskel* Directions_parser_;
 	::xml_schema::string_pskel* Vscale_parser_;
 	::xml_schema::string_pskel* Epoch_parser_;
+	::xml_schema::string_pskel* EpochOfObservation_parser_;
 	::xml_schema::string_pskel* ReferenceFrame_parser_;
 	::GPSBaseline_pskel* GPSBaseline_parser_;
 	::xml_schema::string_pskel* Hscale_parser_;

--- a/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
+++ b/dynadjust/dynadjust/dnaimportwrapper/dnaimportwrapper.cpp
@@ -318,6 +318,29 @@ int ParseCommandLineOptions(const int& argc, char* argv[], const boost::program_
         p.i.user_supplied_epoch = 1;
     }
 
+    if (vm.count(OBSERVATION_EPOCH)) {
+        // Get today's date?
+        if (iequals(p.i.observation_epoch, "today"))
+            p.i.observation_epoch = stringFromToday<boost::gregorian::date>();
+        // Has the user supplied the year only?
+        else if (p.i.observation_epoch.rfind(".") == std::string::npos)
+            p.i.observation_epoch.insert(0, "01.01.");
+
+        if (p.i.observation_epoch.length() < 10) {
+            std::string dateStr = FormatDateString(p.i.observation_epoch);
+            if (dateStr.empty()) {
+                std::cout << std::endl
+                          << "- Error: Cannot parse observation epoch '" << p.i.observation_epoch << "'." << std::endl
+                          << "  Please supply date in the format dd.mm.yyyy" << std::endl
+                          << std::endl;
+                return EXIT_FAILURE;
+            }
+            p.i.observation_epoch = dateStr;
+        }
+
+        p.i.user_supplied_observation_epoch = 1;
+    }
+
     //////////////////////////////////////////////////////////////////////////////
     // Data screening options
     if (vm.count(GET_MSRS_TRANSCENDING_BOX)) p.i.include_transcending_msrs = 1;
@@ -1029,7 +1052,7 @@ int ImportDataFiles(dna_import& parserDynaML, vdnaStnPtr* vStations, vdnaMsrPtr*
                     // Initialise the 'default' datum (frame and epoch) for the project, from the first file, unless the
                     // frame and epoch have been set by the user, in which case InitialiseDatum has already initialised
                     // the datum.
-                    parserDynaML.InitialiseDatum(p.i.reference_frame, p.i.epoch);
+                    parserDynaML.InitialiseDatum(p.i.reference_frame, p.i.epoch, p.i.observation_epoch);
                 } catch (const XMLInteropException& e) {
                     std::stringstream ss;
                     ss << "- Error: ";
@@ -1280,11 +1303,15 @@ int main(int argc, char* argv[]) {
                           (std::string("Project epoch for all stations and measurements when input files do not "
                                        "specify an epoch. Default is ") +
                            p.i.epoch + ".")
-                              .c_str())(OVERRIDE_INPUT_FRAME,
-                                        (std::string("Replace the reference frame specified in the input files with "
-                                                     "the reference frame specified by arg in --") +
-                                         std::string(REFERENCE_FRAME))
-                                            .c_str());
+                              .c_str())(OBSERVATION_EPOCH, boost::program_options::value<std::string>(&p.i.observation_epoch),
+                                        "Default observation epoch (immutable under dnareftran) for "
+                                        "measurements that do not supply one. Format dd.mm.yyyy. "
+                                        "Use special value \"today\" to capture the current date.")(
+                                            OVERRIDE_INPUT_FRAME,
+                                            (std::string("Replace the reference frame specified in the input files with "
+                                                         "the reference frame specified by arg in --") +
+                                             std::string(REFERENCE_FRAME))
+                                                .c_str());
 
         data_screening_options.add_options()(
             BOUNDING_BOX, boost::program_options::value<std::string>(&p.i.bounding_box),
@@ -1511,7 +1538,7 @@ int main(int argc, char* argv[]) {
     // See comments in InitialiseDatum()
     try {
         // Initialise the 'default' datum for the project.
-        parserDynaML.InitialiseDatum(p.i.reference_frame, p.i.epoch);
+        parserDynaML.InitialiseDatum(p.i.reference_frame, p.i.epoch, p.i.observation_epoch);
     } catch (const XMLInteropException& e) {
         std::cout << std::endl << cmd_line_banner;
         imp_file << std::endl << cmd_line_banner;
@@ -1677,6 +1704,25 @@ int main(int argc, char* argv[]) {
     // discontinuities be parsed prior to reading any SINEX files.
     if (vm.count(STATION_DISCONTINUITY_FILE)) {
         p.i.apply_discontinuities = true;
+
+        // Static datums have no meaningful reference-frame epoch, so the discontinuity
+        // matcher will fall back to that (possibly incorrect) value unless the user
+        // supplies an observation epoch per-measurement or via --observation-epoch.
+        // See issue #325.
+        if (isEpsgDatumStatic(epsgCode) && !p.i.user_supplied_observation_epoch) {
+            std::stringstream wss;
+            wss << std::endl
+                << "- Warning: --discontinuity-file is in use with static datum " << p.i.reference_frame
+                << "." << std::endl
+                << "  Station-instance allocation relies on 'Epoch of Observation'. Supply it per-measurement" << std::endl
+                << "  via <EpochOfObservation> / DNA column 25, or set a project default via --observation-epoch." << std::endl
+                << "  Without it, the reference-frame epoch will be used as a fallback, which may be incorrect" << std::endl
+                << "  for a static datum." << std::endl
+                << std::endl;
+            if (!p.g.quiet)
+                std::cout << wss.str();
+            imp_file << wss.str();
+        }
 
         // Does it exist?
         if (!std::filesystem::exists(p.i.stn_discontinuityfile)) {
@@ -2534,6 +2580,12 @@ int main(int argc, char* argv[]) {
             return EXIT_FAILURE;
         }
     }
+
+    // Apply the project-level observation_epoch (from --observation-epoch) to measurements
+    // whose observation_epoch is empty or auto-defaulted from the reference-frame epoch.
+    // No-op when --observation-epoch was not supplied.
+    if (p.i.user_supplied_observation_epoch)
+        parserDynaML.ApplyProjectObservationEpoch((vdnaMsrPtr*)&vmeasurementsTotal);
 
     // Create binary measurement file.
     // Binary measurement file can be serialised without stations

--- a/dynadjust/dynadjust/dnareftran/dnareftran.cpp
+++ b/dynadjust/dynadjust/dnareftran/dnareftran.cpp
@@ -621,6 +621,7 @@ void dna_reftran::WriteBinaryStationFile(const std::string& bstfileName)
 	snprintf(bst_meta_.modifiedBy, sizeof(bst_meta_.modifiedBy), "%s", __BINARY_NAME__);
 	snprintf(bst_meta_.epsgCode, sizeof(bst_meta_.epsgCode), "%s", strEpsg.substr(0, STN_EPSG_WIDTH).c_str());
 	snprintf(bst_meta_.epoch, sizeof(bst_meta_.epoch), "%s", strEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	// observation_epoch is immutable across transformations - intentionally not overwritten.
 	bst_meta_.reftran = true;
 
 	try {
@@ -655,6 +656,7 @@ void dna_reftran::WriteBinaryMeasurementFile(const std::string& bmsfileName)
 	snprintf(bms_meta_.modifiedBy, sizeof(bms_meta_.modifiedBy), "%s", __BINARY_NAME__);
 	snprintf(bms_meta_.epsgCode, sizeof(bms_meta_.epsgCode), "%s", strEpsg.substr(0, STN_EPSG_WIDTH).c_str());
 	snprintf(bms_meta_.epoch, sizeof(bms_meta_.epoch), "%s", strEpoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	// observation_epoch is immutable across transformations - intentionally not overwritten.
 	bms_meta_.reftran = true;
 
 	try {
@@ -1532,6 +1534,7 @@ void dna_reftran::TransformStationRecords(const std::string& newFrame, const std
 			// d. Update meta
 			snprintf(stn_it->epsgCode, sizeof(stn_it->epsgCode), "%s", datumTo_.GetEpsgCode_s().c_str());
 			snprintf(stn_it->epoch, sizeof(stn_it->epoch), "%s", datumTo_.GetEpoch_s().c_str());
+			// observation_epoch is immutable across transformations - intentionally not overwritten.
 			transformationPerformed_ = true;
 			m_stnsTransformed++;
 		}
@@ -1607,15 +1610,15 @@ void dna_reftran::TransformStation(it_vstn_t& stn_it, const CDnaDatum& datumFrom
 
 void dna_reftran::TransformMeasurementRecords(const std::string& newFrame, const std::string& newEpoch)
 {
-	it_vmsr_t msr_it;
+	it_vmsr_t msr_it = bmsBinaryRecords_.end();
 	CDnaDatum datumFrom;
 	data_type_ = msr_data;
-	
+
 	// Create the transformation parameters to be used for the
 	// entire set of measurement records.  If a measurement is in a different
 	// frame, obtain new parameters
 	transformation_parameter_set transformationParameters;
-	
+
 	transformationPerformed_ = false;
 	m_msrsTransformed = m_msrsNotTransformed = 0;
 
@@ -1623,13 +1626,12 @@ void dna_reftran::TransformMeasurementRecords(const std::string& newFrame, const
 	TRACE("\nTransforming measurements...\n\n");
 #endif
 
+	// Setup before the measurement loop - errors here cannot reference a specific measurement
+	datumTo_.SetDatumFromName(newFrame, newEpoch);
+	ApplyToFrameSubstitution();
+
 	try {
-		// 1. Get the datum (and epoch) of the desired system and apply the
-        // appropriate substitution (required to determine the transformation parameters)
-        datumTo_.SetDatumFromName(newFrame, newEpoch);
-        ApplyToFrameSubstitution();
-	
-		// 2. For every measurement, get the datum, determine parameters, then transform
+		// For every measurement, get the datum, determine parameters, then transform
 		for (msr_it=bmsBinaryRecords_.begin(); msr_it!=bmsBinaryRecords_.end(); ++msr_it)
 		{
 			// a. ignore measurements not subject to geodetic datum
@@ -1794,6 +1796,8 @@ void dna_reftran::TransformMeasurement_GX(it_vmsr_t& msr_it, const CDnaDatum& da
 		msr_it->term1 = coordinates2_mod.get(0, 0) - coordinates1_mod.get(0, 0);
 		//TRACE("\nTransformed baseline\n");
 		//TRACE("%.4f\n", msr_it->term1);
+		// observation_epoch is immutable across transformations - the three X/Y/Z
+		// component writes below intentionally overwrite only epsgCode and epoch.
 		snprintf(msr_it->epsgCode, sizeof(msr_it->epsgCode), "%s", datumTo_.GetEpsgCode_s().c_str());
 		snprintf(msr_it->epoch, sizeof(msr_it->epoch), "%s", datumTo_.GetEpoch_s().c_str());
 		msr_it++;
@@ -1884,6 +1888,8 @@ void dna_reftran::TransformMeasurement_Y(it_vmsr_t& msr_it, const CDnaDatum& dat
 		}
 		
 		// Assign 'transformed' elements
+		// observation_epoch is immutable across transformations - the three X/Y/Z
+		// component writes below intentionally overwrite only epsgCode and epoch.
 		msr_it->term1 = coordinates_mod.get(0, 0);
 		snprintf(msr_it->epsgCode, sizeof(msr_it->epsgCode), "%s", datumTo_.GetEpsgCode_s().c_str());
 		snprintf(msr_it->epoch, sizeof(msr_it->epoch), "%s", datumTo_.GetEpoch_s().c_str());

--- a/dynadjust/include/config/dnaoptions-interface.hpp
+++ b/dynadjust/include/config/dnaoptions-interface.hpp
@@ -171,6 +171,7 @@ const char* const REFERENCE_FRAME = "reference-frame";
 const char* const REFERENCE_FRAME_R = "reference-frame,r";
 const char* const EPOCH = "epoch";
 const char* const EPOCH_E = "epoch,e";
+const char* const OBSERVATION_EPOCH = "observation-epoch";
 const char* const OVERRIDE_INPUT_FRAME = "override-input-ref-frame";
 const char* const TECTONIC_PLATE_BDY_FILE = "plate-boundary-file";
 const char* const TECTONIC_PLATE_BDY_FILE_B = "plate-boundary-file,b";

--- a/dynadjust/include/config/dnaoptions.hpp
+++ b/dynadjust/include/config/dnaoptions.hpp
@@ -185,7 +185,7 @@ public:
 struct import_settings : private boost::equality_comparable<import_settings> {
 public:
 	import_settings()
-		: reference_frame(DEFAULT_DATUM), epoch(DEFAULT_EPOCH), user_supplied_frame(0), user_supplied_epoch(0), override_input_rfame(0)
+		: reference_frame(DEFAULT_DATUM), epoch(DEFAULT_EPOCH), observation_epoch(""), user_supplied_frame(0), user_supplied_epoch(0), user_supplied_observation_epoch(0), override_input_rfame(0)
 		, test_integrity(0), verify_coordinates(0), export_dynaml(0), export_from_bfiles(0)
 		, export_single_xml_file(0), prefer_single_x_as_g(0), export_asl_file(0), export_aml_file(0), export_map_file(0)
 		, export_dna_files(0), export_discont_file(0), import_geo_file(0), simulate_measurements(0), split_clusters(0), include_transcending_msrs(0)
@@ -232,9 +232,11 @@ private:
 
 public:
 	std::string		reference_frame;			// Project reference frame - used primarily for reductions on the ellipsoid.
-	std::string		epoch;						// Project epoch
+	std::string		epoch;						// Project epoch (of reference frame)
+	std::string		observation_epoch;			// Default observation epoch applied to measurements with no file-level value
 	UINT16		user_supplied_frame;		// User has supplied a frame - use this to change the default frame
 	UINT16		user_supplied_epoch;		// User has supplied a epoch - use this to change the default epoch
+	UINT16		user_supplied_observation_epoch;	// User has supplied an observation epoch via --observation-epoch
 	UINT16		override_input_rfame;		// Override reference frame specified in input files using the default or user supplied frame.
 	UINT16		test_integrity;				// Test integrity of network
 	UINT16		verify_coordinates;			// Test integrity of coordinates

--- a/dynadjust/include/config/dnatypes-structs.hpp
+++ b/dynadjust/include/config/dnatypes-structs.hpp
@@ -283,6 +283,7 @@ typedef struct stn_t {
 		memset(epsgCode, '\0', sizeof(epsgCode));
 		snprintf(epsgCode, sizeof(epsgCode), "7843");
 		memset(epoch, '\0', sizeof(epoch));
+		memset(observation_epoch, '\0', sizeof(observation_epoch));
 		memset(plate, '\0', sizeof(plate));
 	}
 
@@ -311,9 +312,13 @@ typedef struct stn_t {
 	UINT32	clusterID;						// cluster ID (which cluster this station belongs to)
 	UINT16	unusedStation;					// is this station unused?
 	char	epsgCode[STN_EPSG_WIDTH];		// epsg ID, i.e. NNNNN (where NNNNN is in the range 0-32767)
-	char	epoch[STN_EPOCH_WIDTH];			// date, i.e. "DD.MM.YYYY" (10 chars)
-											// if datum is dynamic, Epoch is YYYY MM DD
-											// if datum is static, Epoch is ignored
+	char	epoch[STN_EPOCH_WIDTH];			// Epoch of Reference Frame, i.e. "DD.MM.YYYY" (10 chars)
+											// Mutable via dnareftran; reflects the reference frame's epoch.
+											// If datum is static, Epoch is ignored.
+	char	observation_epoch[STN_EPOCH_WIDTH];	// Epoch of Observation, i.e. "DD.MM.YYYY" (10 chars)
+											// Immutable under reftran. Timestamp at which the station
+											// coordinates were observed/measured. Used for discontinuity
+											// station-instance allocation. Empty if not supplied.
 	char	plate[STN_PLATE_WIDTH];			// Tectonic plate identifier. Typically two characters.
 } station_t;
 
@@ -330,7 +335,8 @@ typedef v_stn_string::iterator it_stn_string;
 typedef struct input_file_meta {
 	char	filename[FILE_NAME_WIDTH+1];	// Input file path
 	char	epsgCode[STN_EPSG_WIDTH+1];		// Input file epsg ID, i.e. NNNNN (where NNNNN is in the range 0-32767). "Mixed" if stations are on different reference frames
-	char	epoch[STN_EPOCH_WIDTH+1];		// Input file epoch
+	char	epoch[STN_EPOCH_WIDTH+1];		// Input file reference frame epoch (mutable)
+	char	observation_epoch[STN_EPOCH_WIDTH+1];	// Input file observation epoch (immutable)
 	UINT16	filetype;						// Input file type (geodesyml, dynaml, dna, csv, sinex)
 	UINT16	datatype;						// Input data type (station, measurement, both)
 } input_file_meta_t;
@@ -371,6 +377,7 @@ typedef struct binary_file_meta {
 		memcpy(modifiedBy, rhs.modifiedBy, sizeof(modifiedBy));
 		memcpy(epsgCode, rhs.epsgCode, sizeof(epsgCode));
 		memcpy(epoch, rhs.epoch, sizeof(epoch));
+		memcpy(observation_epoch, rhs.observation_epoch, sizeof(observation_epoch));
 		rhs.inputFileMeta = nullptr;
 		rhs.sourceFileMeta = nullptr;
 	}
@@ -388,6 +395,7 @@ typedef struct binary_file_meta {
 			memcpy(modifiedBy, rhs.modifiedBy, sizeof(modifiedBy));
 			memcpy(epsgCode, rhs.epsgCode, sizeof(epsgCode));
 			memcpy(epoch, rhs.epoch, sizeof(epoch));
+			memcpy(observation_epoch, rhs.observation_epoch, sizeof(observation_epoch));
 			inputFileCount = rhs.inputFileCount;
 			inputFileMeta = rhs.inputFileMeta;
 			sourceFileCount = rhs.sourceFileCount;
@@ -401,7 +409,8 @@ typedef struct binary_file_meta {
 	bool				reduced;						// indicates whether the data is reduced(true) or raw(false)
 	char				modifiedBy[MOD_NAME_WIDTH+1];	// the program that modified this file
 	char				epsgCode[STN_EPSG_WIDTH+1];		// epsg ID, i.e. NNNNN (where NNNNN is in the range 0-32767). "Mixed" if stations are on different reference frames
-	char				epoch[STN_EPOCH_WIDTH+1];		// date, i.e. "DD.MM.YYYY" (10 chars)
+	char				epoch[STN_EPOCH_WIDTH+1];		// Epoch of Reference Frame (mutable)
+	char				observation_epoch[STN_EPOCH_WIDTH+1];	// Epoch of Observation (immutable; preserved across reftran)
 	bool				reftran;						// the data has been transformed to another frame and/or epoch
 	bool				geoid;							// geoid separation values have been obtained
     std::uint64_t		inputFileCount;					// Number of source file metadata elements

--- a/dynadjust/include/io/bms_file.cpp
+++ b/dynadjust/include/io/bms_file.cpp
@@ -147,6 +147,14 @@ std::uint64_t BmsFile::LoadFile(const std::string& bms_filename,
     ReadFileInfo(bms_file);
     ReadFileMetadata(bms_file, bms_meta);
 
+    // measurement_t grew by observation_epoch in v1.2; record layout requires a v1.2 file.
+    if (!versionAtLeast(1, 2)) {
+      std::ostringstream os;
+      os << "BMS file version " << GetVersion()
+         << " predates observation_epoch support (v1.2); please re-run dnaimport.";
+      throw std::runtime_error(os.str());
+    }
+
     vbinary_msr->reserve(bms_meta.binCount);
     for (msr = 0; msr < bms_meta.binCount; msr++) {
       bms_file.read(reinterpret_cast<char*>(&measRecord),

--- a/dynadjust/include/io/bst_file.cpp
+++ b/dynadjust/include/io/bst_file.cpp
@@ -128,6 +128,14 @@ std::uint64_t BstFile::LoadFile(const std::string& bst_filename,
     ReadFileInfo(bst_file);
     ReadFileMetadata(bst_file, bst_meta);
 
+    // station_t grew by observation_epoch in v1.2; bulk I/O requires a v1.2 layout.
+    if (!versionAtLeast(1, 2)) {
+      std::ostringstream os;
+      os << "BST file version " << GetVersion()
+         << " predates observation_epoch support (v1.2); please re-run dnaimport.";
+      throw std::runtime_error(os.str());
+    }
+
     vbinary_stn->resize(bst_meta.binCount);
     static_assert(std::is_trivially_copyable_v<station_t>,
                   "station_t must be trivially copyable for bulk I/O");

--- a/dynadjust/include/io/dnaiodnatypes.hpp
+++ b/dynadjust/include/io/dnaiodnatypes.hpp
@@ -94,6 +94,7 @@ typedef struct {
 	UINT32 msr_targ_ht;
 	UINT32 msr_id_msr;
 	UINT32 msr_id_cluster;
+	UINT32 msr_gps_obs_epoch;	// DNA v3.02+ column; 0 if file predates v3.02
 } dna_msr_fields;
 
 // DNA version 1.00
@@ -440,6 +441,82 @@ public:
 };
 
 
+// DNA version 3.02 - adds a 25th column for the observation epoch.
+// Columns 0-23 are identical to version 3.01.
+template <class U>
+struct _dna_msr_fields_302_
+{
+	static const U _locations_[25];
+	static const U _widths_[25];
+};
+
+template <class U>
+const U _dna_msr_fields_302_<U>::_locations_[25] =
+{
+	0,		// msr type
+	1,		// ignore
+	2,		// instrument name
+	22,		// target 1
+	42,		// target 2
+	62,		// linear measurement
+	62,		// gps measurement
+	82,		// gps vcv 1
+	102,	// gps vcv 2
+	122,	// gps vcv 3
+	62,		// gps vscale
+	72,		// gps pscale
+	82,		// gps lscale
+	92,		// gps hscale
+	102,	// gps ref frame
+	122,	// gps epoch (reference-frame epoch)
+	76,		// angular d
+	80,		// angular m
+	82,		// angular s
+	90,		// standard deviation
+	99,		// inst height
+	106,	// target height
+	142,	// msr id
+	152,	// cluster id
+	162		// gps observation epoch
+};
+
+template <class U>
+const U _dna_msr_fields_302_<U>::_widths_[25] =
+{
+	1,		// msr type
+	1,		// ignore
+	20,		// instrument name
+	20,		// target 1
+	20,		// target 2
+	14,		// linear measurement
+	20,		// gps measurement
+	20,		// gps vcv 1
+	20,		// gps vcv 2
+	20,		// gps vcv 3
+	10,		// gps vscale
+	10,		// gps pscale
+	10,		// gps lscale
+	10,		// gps hscale
+	20,		// gps ref frame
+	20,		// gps epoch (reference-frame epoch)
+	4,		// angular d
+	2,		// angular m
+	8,		// angular s
+	9,		// standard deviation
+	7,		// inst height
+	7,		// target height
+	10,		// msr id
+	10,		// cluster id
+	20		// gps observation epoch
+};
+
+class dna_msr_fields_302
+	: public _dna_msr_fields_302_<UINT16>
+{
+public:
+};
+
+
 
 template <typename U>
 void assignDNASTNFieldParameters(const UINT16* locs, const UINT16* widths, 
@@ -523,7 +600,9 @@ void assignDNAMSRFieldParameters(const UINT16* locs, const UINT16* widths,
 	dflocs.msr_targ_ht = locs[21];
 	dflocs.msr_id_msr = locs[22];
 	dflocs.msr_id_cluster = locs[23];
-	
+	// Default the 3.02-introduced field to 0; a v3.02 branch overrides it below.
+	dflocs.msr_gps_obs_epoch = 0;
+
 	dfwidths.msr_type = widths[0];
 	dfwidths.msr_ignore = widths[1];
 	dfwidths.msr_inst = widths[2];
@@ -548,14 +627,26 @@ void assignDNAMSRFieldParameters(const UINT16* locs, const UINT16* widths,
 	dfwidths.msr_targ_ht = widths[21];
 	dfwidths.msr_id_msr = widths[22];
 	dfwidths.msr_id_cluster = widths[23];
-	
+	dfwidths.msr_gps_obs_epoch = 0;
 }
 	
 
 template <typename U>
-void determineDNAMSRFieldParameters(const std::string& version, 
+void determineDNAMSRFieldParameters(const std::string& version,
 	dna_msr_fields& dflocs, dna_msr_fields& dfwidths, const U u=0)
 {
+	if (iequals(version, "3.02"))
+	{
+		assignDNAMSRFieldParameters<U>(dna_msr_fields_302::_locations_,
+			dna_msr_fields_302::_widths_,
+			dflocs, dfwidths);
+		// The 3.02-introduced observation-epoch column is beyond the shared
+		// 24-entry assigner, so set it explicitly here.
+		dflocs.msr_gps_obs_epoch = dna_msr_fields_302::_locations_[24];
+		dfwidths.msr_gps_obs_epoch = dna_msr_fields_302::_widths_[24];
+		return;
+	}
+
 	if (iequals(version, "3.01"))
 	{
 		assignDNAMSRFieldParameters<U>(dna_msr_fields_301::_locations_,

--- a/dynadjust/include/io/dnaiosnxread.cpp
+++ b/dynadjust/include/io/dnaiosnxread.cpp
@@ -939,10 +939,15 @@ void DnaIoSnx::ParseSinexStn(std::ifstream** snx_file, const char* sinexRec, vdn
 				stn_ptr->SetReferenceFrame(datum.GetName());
 				stn_ptr->SetEpsg(datum.GetEpsgCode_s());
 
-				yy = LongFromString<UINT32>(sBuf.substr(27, 2)), 
-				doy = LongFromString<UINT32>(sBuf.substr(30, 3)), 
+				yy = LongFromString<UINT32>(sBuf.substr(27, 2)),
+				doy = LongFromString<UINT32>(sBuf.substr(30, 3)),
 				ss = ParseDateFromYyDoy(yy, doy, doy_yyyy, std::string(" "));
-				stn_ptr->SetEpoch(stringFromDate(dateFromStringstream_doy_year<boost::gregorian::date, std::stringstream>(ss)));
+				{
+					std::string sinex_epoch = stringFromDate(dateFromStringstream_doy_year<boost::gregorian::date, std::stringstream>(ss));
+					stn_ptr->SetEpoch(sinex_epoch);
+					// SINEX STAX YY:DOY is the observation data window start — record it as the immutable observation epoch
+					stn_ptr->SetObservationEpoch(sinex_epoch);
+				}
 
 				stn_ptr->SetfileOrder(fileOrder++);
 				stn_ptr->SetXAxis_d(DoubleFromString<double>(trimstr(sBuf.substr(47, 21))));
@@ -1310,6 +1315,7 @@ void DnaIoSnx::ParseSinexMsr(std::ifstream** snx_file, const char* sinexRec, vdn
 	dnaGpsPointCluster->SetReferenceFrame(datum.GetName());
 	dnaGpsPointCluster->SetEpsg(datum.GetEpsgCode_s());
 	dnaGpsPointCluster->SetEpoch(vStations->at(0)->GetEpoch());
+	dnaGpsPointCluster->SetObservationEpoch(vStations->at(0)->GetObservationEpoch());
 
 	UINT32 cov_count, ci;
 
@@ -1328,6 +1334,7 @@ void DnaIoSnx::ParseSinexMsr(std::ifstream** snx_file, const char* sinexRec, vdn
 		dnaGpsPoint->SetReferenceFrame(datum.GetName());
 		dnaGpsPoint->SetEpsg(datum.GetEpsgCode_s());
 		dnaGpsPoint->SetEpoch(vStations->at(p)->GetEpoch());
+		dnaGpsPoint->SetObservationEpoch(vStations->at(p)->GetObservationEpoch());
 
 		dnaGpsPoint->SetPscale(dnaGpsPointCluster->GetPscale());
 		dnaGpsPoint->SetLscale(dnaGpsPointCluster->GetLscale());

--- a/dynadjust/include/io/dynadjust_file.cpp
+++ b/dynadjust/include/io/dynadjust_file.cpp
@@ -83,24 +83,28 @@ void DynadjustFile::ReadFileInfo(std::ifstream& file_stream)
 void DynadjustFile::WriteFileMetadata(std::ofstream& file_stream, binary_file_meta_t& file_meta)
 {
 	// Write the metadata
-	file_stream.write(reinterpret_cast<char *>(&file_meta.binCount), sizeof(std::uint64_t)); 
-	file_stream.write(reinterpret_cast<char *>(&file_meta.reduced), sizeof(bool)); 
-	file_stream.write(reinterpret_cast<char *>(file_meta.modifiedBy), MOD_NAME_WIDTH); 
-	
-	// Write the epsg code and epoch
+	file_stream.write(reinterpret_cast<char *>(&file_meta.binCount), sizeof(std::uint64_t));
+	file_stream.write(reinterpret_cast<char *>(&file_meta.reduced), sizeof(bool));
+	file_stream.write(reinterpret_cast<char *>(file_meta.modifiedBy), MOD_NAME_WIDTH);
+
+	// Write the epsg code and epochs (reference frame + observation)
 	file_stream.write(reinterpret_cast<char *>(file_meta.epsgCode), STN_EPSG_WIDTH);
 	file_stream.write(reinterpret_cast<char *>(file_meta.epoch), STN_EPOCH_WIDTH);
+	// v1.2+: write observation_epoch after reference-frame epoch
+	file_stream.write(reinterpret_cast<char *>(file_meta.observation_epoch), STN_EPOCH_WIDTH);
 
 	file_stream.write(reinterpret_cast<char*>(&file_meta.reftran), sizeof(bool));
 	file_stream.write(reinterpret_cast<char*>(&file_meta.geoid), sizeof(bool));
 
 	// Write file count and file meta
-	file_stream.write(reinterpret_cast<char *>(&file_meta.inputFileCount), sizeof(std::uint64_t)); 
+	file_stream.write(reinterpret_cast<char *>(&file_meta.inputFileCount), sizeof(std::uint64_t));
 	for (std::uint64_t i(0); i<file_meta.inputFileCount; ++i)
 	{
-		file_stream.write(reinterpret_cast<char *>(file_meta.inputFileMeta[i].filename), FILE_NAME_WIDTH); 
+		file_stream.write(reinterpret_cast<char *>(file_meta.inputFileMeta[i].filename), FILE_NAME_WIDTH);
 		file_stream.write(reinterpret_cast<char *>(file_meta.inputFileMeta[i].epsgCode), STN_EPSG_WIDTH);
 		file_stream.write(reinterpret_cast<char *>(file_meta.inputFileMeta[i].epoch), STN_EPOCH_WIDTH);
+		// v1.2+: observation_epoch per input file
+		file_stream.write(reinterpret_cast<char *>(file_meta.inputFileMeta[i].observation_epoch), STN_EPOCH_WIDTH);
 		file_stream.write(reinterpret_cast<char *>(&file_meta.inputFileMeta[i].filetype), sizeof(UINT16));
 		file_stream.write(reinterpret_cast<char *>(&file_meta.inputFileMeta[i].datatype), sizeof(UINT16));
 	}
@@ -114,14 +118,24 @@ void DynadjustFile::WriteFileMetadata(std::ofstream& file_stream, binary_file_me
 
 void DynadjustFile::ReadFileMetadata(std::ifstream& file_stream, binary_file_meta_t& file_meta)
 {
+	const bool has_observation_epoch = versionAtLeast(1, 2);
+
 	// Read the metadata
-	file_stream.read(reinterpret_cast<char *>(&file_meta.binCount), sizeof(std::uint64_t)); 
-	file_stream.read(reinterpret_cast<char *>(&file_meta.reduced), sizeof(bool)); 
+	file_stream.read(reinterpret_cast<char *>(&file_meta.binCount), sizeof(std::uint64_t));
+	file_stream.read(reinterpret_cast<char *>(&file_meta.reduced), sizeof(bool));
 	file_stream.read(reinterpret_cast<char *>(file_meta.modifiedBy), MOD_NAME_WIDTH);
 
 	// Read the epsg code and epoch
 	file_stream.read(reinterpret_cast<char *>(file_meta.epsgCode), STN_EPSG_WIDTH);
 	file_stream.read(reinterpret_cast<char *>(file_meta.epoch), STN_EPOCH_WIDTH);
+
+	// v1.2+: observation_epoch follows the reference-frame epoch.
+	// Older files fall back to observation_epoch = epoch so legacy files remain loadable
+	// without changing semantics (discontinuity matching uses epoch if observation is empty).
+	if (has_observation_epoch)
+		file_stream.read(reinterpret_cast<char *>(file_meta.observation_epoch), STN_EPOCH_WIDTH);
+	else
+		memcpy(file_meta.observation_epoch, file_meta.epoch, STN_EPOCH_WIDTH);
 
 	file_stream.read(reinterpret_cast<char*>(&file_meta.reftran), sizeof(bool));
 	file_stream.read(reinterpret_cast<char*>(&file_meta.geoid), sizeof(bool));
@@ -132,12 +146,16 @@ void DynadjustFile::ReadFileMetadata(std::ifstream& file_stream, binary_file_met
 		delete []file_meta.inputFileMeta;
 
 	file_meta.inputFileMeta = new input_file_meta_t[file_meta.inputFileCount];
-		
+
 	for (std::uint64_t i(0); i<file_meta.inputFileCount; ++i)
 	{
-		file_stream.read(reinterpret_cast<char *>(file_meta.inputFileMeta[i].filename), FILE_NAME_WIDTH); 
+		file_stream.read(reinterpret_cast<char *>(file_meta.inputFileMeta[i].filename), FILE_NAME_WIDTH);
 		file_stream.read(reinterpret_cast<char *>(file_meta.inputFileMeta[i].epsgCode), STN_EPSG_WIDTH);
 		file_stream.read(reinterpret_cast<char *>(file_meta.inputFileMeta[i].epoch), STN_EPOCH_WIDTH);
+		if (has_observation_epoch)
+			file_stream.read(reinterpret_cast<char *>(file_meta.inputFileMeta[i].observation_epoch), STN_EPOCH_WIDTH);
+		else
+			memcpy(file_meta.inputFileMeta[i].observation_epoch, file_meta.inputFileMeta[i].epoch, STN_EPOCH_WIDTH);
 		file_stream.read(reinterpret_cast<char *>(&file_meta.inputFileMeta[i].filetype), sizeof(UINT16));
 		file_stream.read(reinterpret_cast<char *>(&file_meta.inputFileMeta[i].datatype), sizeof(UINT16));
 	}

--- a/dynadjust/include/io/dynadjust_file.hpp
+++ b/dynadjust/include/io/dynadjust_file.hpp
@@ -37,7 +37,7 @@
 #include <include/config/dnatypes-fwd.hpp>
 #include <include/config/dnatypes-structs.hpp>
 
-#define __FILE_VERSION__ "1.1"
+#define __FILE_VERSION__ "1.2"
 
 namespace dynadjust {
 namespace iostreams {

--- a/dynadjust/include/measurement_types/dnaangle.cpp
+++ b/dynadjust/include/measurement_types/dnaangle.cpp
@@ -250,6 +250,7 @@ UINT32 CDnaAngle::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_msr, 
 	m_dStdDev = sqrt(it_msr->term2);
 	
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
@@ -278,6 +279,7 @@ void CDnaAngle::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex) c
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnacoordinate.cpp
+++ b/dynadjust/include/measurement_types/dnacoordinate.cpp
@@ -202,6 +202,7 @@ UINT32 CDnaCoordinate::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_
 	m_dStdDev = sqrt(it_msr->term2);
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
@@ -229,6 +230,7 @@ void CDnaCoordinate::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrInd
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnadirection.cpp
+++ b/dynadjust/include/measurement_types/dnadirection.cpp
@@ -65,6 +65,7 @@ CDnaDirection::CDnaDirection(CDnaDirection&& d)
 	m_msr_db_map = d.m_msr_db_map;
 
 	m_epoch = d.m_epoch;
+	m_observation_epoch = d.m_observation_epoch;
 }
 
 // move assignment operator 
@@ -599,13 +600,14 @@ UINT32 CDnaDirection::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_m
 	m_dStdDev = sqrt(it_msr->term2);
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
-	
+
 	return 0;
 }
-	
+
 
 void CDnaDirection::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex) const
 {
@@ -636,6 +638,7 @@ void CDnaDirection::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrInde
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnadirectionset.cpp
+++ b/dynadjust/include/measurement_types/dnadirectionset.cpp
@@ -394,6 +394,7 @@ UINT32 CDnaDirectionSet::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& i
 	m_lsetID = it_msr->clusterID;
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	m_vTargetDirections.clear();
@@ -455,6 +456,7 @@ void CDnaDirectionSet::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrI
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 

--- a/dynadjust/include/measurement_types/dnadistance.cpp
+++ b/dynadjust/include/measurement_types/dnadistance.cpp
@@ -283,6 +283,7 @@ UINT32 CDnaDistance::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_ms
 	m_dStdDev = sqrt(it_msr->term2);
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
@@ -313,6 +314,7 @@ void CDnaDistance::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnagpsbaseline.cpp
+++ b/dynadjust/include/measurement_types/dnagpsbaseline.cpp
@@ -76,7 +76,8 @@ CDnaGpsBaseline::CDnaGpsBaseline(CDnaGpsBaseline&& g)
 	m_referenceFrame = g.m_referenceFrame;
 	m_epsgCode = g.m_epsgCode;
 	m_epoch = g.m_epoch;
-	
+	m_observation_epoch = g.m_observation_epoch;
+
 	m_dX = g.m_dX;
 	m_dY = g.m_dY;
 	m_dZ = g.m_dZ;
@@ -114,6 +115,7 @@ CDnaGpsBaseline& CDnaGpsBaseline::operator= (CDnaGpsBaseline&& rhs)
 	m_referenceFrame = rhs.m_referenceFrame;
 	m_epsgCode = rhs.m_epsgCode;
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 
 	m_dX = rhs.m_dX;
 	m_dY = rhs.m_dY;
@@ -371,6 +373,7 @@ UINT32 CDnaGpsBaseline::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it
 	m_dVscale = it_msr->scale4;
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_epsgCode = it_msr->epsgCode;
 	m_referenceFrame = datumFromEpsgString<std::string>(it_msr->epsgCode);
 
@@ -437,6 +440,7 @@ void CDnaGpsBaseline::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIn
 
 	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measAdj = m_measAdj;
@@ -485,7 +489,7 @@ void CDnaGpsBaseline::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIn
 	// now write covariance elements
 	std::vector<CDnaCovariance>::const_iterator _it_cov;
 	for (_it_cov=m_vGpsCovariances.begin(); _it_cov!=m_vGpsCovariances.end(); ++_it_cov)
-		_it_cov->WriteBinaryMsr(binary_stream, msrIndex, m_epsgCode, m_epoch);
+		_it_cov->WriteBinaryMsr(binary_stream, msrIndex, m_epsgCode, m_epoch, m_observation_epoch);
 }
 
 void CDnaGpsBaseline::SerialiseDatabaseMap(std::ofstream* os)
@@ -650,17 +654,18 @@ CDnaGpsBaselineCluster::CDnaGpsBaselineCluster(CDnaGpsBaselineCluster&& g)
 	m_dVscale = g.m_dVscale;
 	m_lclusterID = g.m_lclusterID;
 	m_MSmeasurementStations = g.m_MSmeasurementStations;
-	
+
 	m_referenceFrame = g.m_referenceFrame;
 	m_epsgCode = g.m_epsgCode;
 	m_epoch = g.m_epoch;
+	m_observation_epoch = g.m_observation_epoch;
 
 	m_msr_db_map = g.m_msr_db_map;
 
 	m_dbidmap = g.m_dbidmap;
 }
 
-// move assignment operator 
+// move assignment operator
 CDnaGpsBaselineCluster& CDnaGpsBaselineCluster::operator= (CDnaGpsBaselineCluster&& rhs)
 {
 	// check for assignment to self!
@@ -674,6 +679,7 @@ CDnaGpsBaselineCluster& CDnaGpsBaselineCluster::operator= (CDnaGpsBaselineCluste
 	m_referenceFrame = rhs.m_referenceFrame;
 	m_epsgCode = rhs.m_epsgCode;
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 
 	m_dPscale = rhs.m_dPscale;
 	m_dLscale = rhs.m_dLscale;
@@ -891,6 +897,7 @@ UINT32 CDnaGpsBaselineCluster::SetMeasurementRec(const vstn_t& binaryStn, it_vms
 
 	m_referenceFrame = datumFromEpsgString<std::string>(it_msr->epsgCode);
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_epsgCode = it_msr->epsgCode;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 

--- a/dynadjust/include/measurement_types/dnagpspoint.cpp
+++ b/dynadjust/include/measurement_types/dnagpspoint.cpp
@@ -78,6 +78,7 @@ CDnaGpsPoint::CDnaGpsPoint(CDnaGpsPoint&& p)
 	m_referenceFrame = p.m_referenceFrame;
 	m_epsgCode = p.m_epsgCode;
 	m_epoch = p.m_epoch;
+	m_observation_epoch = p.m_observation_epoch;
 
 	m_dX = p.m_dX;
 	m_dY = p.m_dY;
@@ -95,7 +96,7 @@ CDnaGpsPoint::CDnaGpsPoint(CDnaGpsPoint&& p)
 	m_dVscale = p.m_dVscale;
 
 	SetCoordType(p.m_strCoordType);
-	
+
 	m_lclusterID = p.m_lclusterID;
 	m_MSmeasurementStations = p.m_MSmeasurementStations;
 
@@ -117,6 +118,7 @@ CDnaGpsPoint& CDnaGpsPoint::operator= (CDnaGpsPoint&& rhs)
 	m_referenceFrame = rhs.m_referenceFrame;
 	m_epsgCode = rhs.m_epsgCode;
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 
 	m_dX = rhs.m_dX;
 	m_dY = rhs.m_dY;
@@ -134,7 +136,7 @@ CDnaGpsPoint& CDnaGpsPoint::operator= (CDnaGpsPoint&& rhs)
 	m_dVscale = rhs.m_dVscale;
 
 	SetCoordType(rhs.m_strCoordType);
-	
+
 	m_lclusterID = rhs.m_lclusterID;
 	m_MSmeasurementStations = rhs.m_MSmeasurementStations;
 
@@ -478,12 +480,13 @@ UINT32 CDnaGpsPoint::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_ms
 	m_dVscale = it_msr->scale4;
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_epsgCode = it_msr->epsgCode;
 	m_referenceFrame = datumFromEpsgCode<std::string, UINT32>(LongFromString<UINT32>(it_msr->epsgCode));
 
 	m_lclusterID = it_msr->clusterID;
 	m_MSmeasurementStations = (MEASUREMENT_STATIONS)it_msr->measurementStations;
-	
+
 	// X, sigmaXX
 	m_bIgnore = it_msr->ignore;
 	m_strType = it_msr->measType;
@@ -548,6 +551,7 @@ void CDnaGpsPoint::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex
 
 	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measAdj = m_measAdj;
@@ -596,7 +600,7 @@ void CDnaGpsPoint::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex
 	// now write covariance elements
 	std::vector<CDnaCovariance>::const_iterator _it_cov;
 	for (_it_cov=m_vPointCovariances.begin(); _it_cov!=m_vPointCovariances.end(); ++_it_cov)
-		_it_cov->WriteBinaryMsr(binary_stream, msrIndex, m_epsgCode, m_epoch);
+		_it_cov->WriteBinaryMsr(binary_stream, msrIndex, m_epsgCode, m_epoch, m_observation_epoch);
 }
 
 
@@ -756,6 +760,7 @@ CDnaGpsPointCluster::CDnaGpsPointCluster(CDnaGpsPointCluster&& p)
 	m_referenceFrame = p.m_referenceFrame;
 	m_epsgCode = p.m_epsgCode;
 	m_epoch = p.m_epoch;
+	m_observation_epoch = p.m_observation_epoch;
 
 	m_msr_db_map = p.m_msr_db_map;
 
@@ -776,6 +781,7 @@ CDnaGpsPointCluster& CDnaGpsPointCluster::operator= (CDnaGpsPointCluster&& rhs)
 	m_referenceFrame = rhs.m_referenceFrame;
 	m_epsgCode = rhs.m_epsgCode;
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 
 	m_dPscale = rhs.m_dPscale;
 	m_dLscale = rhs.m_dLscale;
@@ -1014,6 +1020,7 @@ UINT32 CDnaGpsPointCluster::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t
 
 	m_referenceFrame = datumFromEpsgCode<std::string, UINT32>(LongFromString<UINT32>(it_msr->epsgCode));
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_epsgCode = it_msr->epsgCode;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 

--- a/dynadjust/include/measurement_types/dnaheight.cpp
+++ b/dynadjust/include/measurement_types/dnaheight.cpp
@@ -184,6 +184,7 @@ UINT32 CDnaHeight::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_msr,
 	m_dStdDev = sqrt(it_msr->term2);
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
@@ -213,6 +214,7 @@ void CDnaHeight::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex) 
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnaheightdifference.cpp
+++ b/dynadjust/include/measurement_types/dnaheightdifference.cpp
@@ -220,6 +220,7 @@ UINT32 CDnaHeightDifference::SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_
 	m_dStdDev = sqrt(it_msr->term2);
 
 	m_epoch = it_msr->epoch;
+	m_observation_epoch = it_msr->observation_epoch;
 	m_sourceFileIndex = it_msr->sourceFileIndex;
 
 	CDnaMeasurement::SetDatabaseMap(*dbidmap);
@@ -248,6 +249,7 @@ void CDnaHeightDifference::WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 
 	measRecord.fileOrder = ((*msrIndex)++);
 
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&measRecord), sizeof(measurement_t));
 }

--- a/dynadjust/include/measurement_types/dnameasurement.cpp
+++ b/dynadjust/include/measurement_types/dnameasurement.cpp
@@ -221,19 +221,20 @@ UINT32 CDnaCovariance::SetMeasurementRec(const vstn_t&, it_vmsr_t& it_msr)
 }
 	
 
-void CDnaCovariance::WriteBinaryMsr(std::ofstream *binary_stream, PUINT32 msrIndex, const std::string& epsgCode, const std::string& epoch) const
+void CDnaCovariance::WriteBinaryMsr(std::ofstream *binary_stream, PUINT32 msrIndex, const std::string& epsgCode, const std::string& epoch, const std::string& observation_epoch) const
 {
 	*msrIndex += 3;
 	measurement_t measRecord;
 
 	// Common
 	measRecord.measType = GetTypeC();
-	measRecord.station1 = m_lstn1Index;	
-	measRecord.station2 = m_lstn2Index;	
+	measRecord.station1 = m_lstn1Index;
+	measRecord.station2 = m_lstn2Index;
 	measRecord.clusterID = m_lclusterID;
-	
+
 	snprintf(measRecord.epsgCode, sizeof(measRecord.epsgCode), "%s", epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
 	snprintf(measRecord.epoch, sizeof(measRecord.epoch), "%s", epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	snprintf(measRecord.observation_epoch, sizeof(measRecord.observation_epoch), "%s", observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 
 	// X
 	measRecord.measStart = xCov;
@@ -360,6 +361,7 @@ CDnaMeasurement::CDnaMeasurement()
 	, m_epsgCode(DEFAULT_EPSG_S)
 	, m_sourceFileIndex(0)
 	, m_epoch("")
+	, m_observation_epoch("")
 	, m_bInsufficient(false)
 {
 }
@@ -388,6 +390,7 @@ CDnaMeasurement::CDnaMeasurement(CDnaMeasurement&& m)
 	m_preAdjCorr = m.m_preAdjCorr;
 
 	m_epoch = m.m_epoch;
+	m_observation_epoch = m.m_observation_epoch;
 	m_epsgCode = m.m_epsgCode;
 	m_sourceFileIndex = m.m_sourceFileIndex;
 
@@ -419,6 +422,7 @@ CDnaMeasurement& CDnaMeasurement::operator= (CDnaMeasurement&& rhs)
 	m_preAdjCorr = rhs.m_preAdjCorr;
 
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 	m_epsgCode = rhs.m_epsgCode;
 	m_sourceFileIndex = rhs.m_sourceFileIndex;
 
@@ -501,6 +505,16 @@ void CDnaMeasurement::SerialiseDatabaseMap(std::ofstream* os)
 void CDnaMeasurement::SetEpoch(const std::string& epoch)
 {
 	m_epoch = epoch;
+	// Default the (immutable) observation epoch to the reference-frame epoch
+	// when it has not been explicitly supplied. Legacy DNA v3.01 / DynaML
+	// files without <EpochOfObservation> thus behave identically to before.
+	if (m_observation_epoch.empty())
+		m_observation_epoch = epoch;
+}
+
+void CDnaMeasurement::SetObservationEpoch(const std::string& observation_epoch)
+{
+	m_observation_epoch = observation_epoch;
 }
 
 }	// namespace measurements

--- a/dynadjust/include/measurement_types/dnameasurement.hpp
+++ b/dynadjust/include/measurement_types/dnameasurement.hpp
@@ -144,15 +144,20 @@ typedef struct msr_t {
 			memset(epsgCode, '\0', sizeof(epsgCode));
 			snprintf(epsgCode, sizeof(epsgCode), DEFAULT_EPSG_S);
 			memset(epoch, '\0', sizeof(epoch));
+			memset(observation_epoch, '\0', sizeof(observation_epoch));
 	}
 
 	char	measType;				// 'A', 'S', 'X', ... , etc.
 	char	measStart;				// Start of a measurement (0=start or X, 1=Y, 2=Z, 3=covX, 4=covY, 5=covZ)
 	char	measurementStations;	// One-, two- or three-station measurement
 	char	epsgCode[7];			// epsg ID, i.e. NNNNN (where NNNNN is in the range 0-32767)
-	char	epoch[12];				// date, i.e. "DD.MM.YYYY" (10 chars)
-									// if datum is dynamic, Epoch is YYYY MM DD
-									// if datum is static, Epoch is ignored
+	char	epoch[STN_EPOCH_WIDTH];	// Epoch of Reference Frame, i.e. "DD.MM.YYYY" (10 chars)
+									// Mutable via dnareftran.
+									// If datum is static, Epoch is ignored.
+	char	observation_epoch[STN_EPOCH_WIDTH];	// Epoch of Observation, i.e. "DD.MM.YYYY" (10 chars)
+									// Immutable under reftran. Timestamp at which the measurement
+									// was observed. Used for discontinuity station-instance
+									// allocation. Empty if not supplied.
 	char	coordType[4];			// "LLH", "UTM", ... , etc.
 	bool	ignore;
 	UINT32	station1;        		// stations 1, 2 and 3 are indices to
@@ -221,7 +226,7 @@ public:
 	inline bool GetIgnore() const { return m_bIgnore; }
 
 	inline virtual UINT32 CalcBinaryRecordCount() const { return 3; }
-	void WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex, const std::string& epsgCode, const std::string& epoch) const;
+	void WriteBinaryMsr(std::ofstream* binary_stream, PUINT32 msrIndex, const std::string& epsgCode, const std::string& epoch, const std::string& observation_epoch) const;
 	virtual UINT32 SetMeasurementRec(const vstn_t& binaryStn, it_vmsr_t& it_msr);
 	virtual void WriteDynaMLMsr(std::ofstream* dynaml_stream) const;
 	virtual void WriteDNAMsr(std::ofstream* dna_stream, 
@@ -374,6 +379,7 @@ public:
 
 	virtual inline std::string GetReferenceFrame() const { return ""; }
 	inline std::string GetEpoch() const { return m_epoch; }
+	inline std::string GetObservationEpoch() const { return m_observation_epoch; }
 	
 	virtual inline std::vector<CDnaGpsBaseline>* GetBaselines_ptr() { return 0; }
 	virtual inline std::vector<CDnaDirection>* GetDirections_ptr() { return 0; }
@@ -402,6 +408,7 @@ public:
 	
 	virtual void SetReferenceFrame(const std::string&) {}
 	void SetEpoch(const std::string& epoch);
+	void SetObservationEpoch(const std::string& observation_epoch);
 	
 	virtual void SetLscale(const std::string&) {}
 	virtual void SetLscale(const double&) {}
@@ -485,7 +492,8 @@ protected:
 	UINT32		m_sourceFileIndex;
 
 	std::string	m_epoch;
-	
+	std::string	m_observation_epoch;
+
 	msr_database_id_map		m_msr_db_map;
 
 	bool	m_bInsufficient;

--- a/dynadjust/include/measurement_types/dnastation.cpp
+++ b/dynadjust/include/measurement_types/dnastation.cpp
@@ -120,7 +120,7 @@ CDnaStation::CDnaStation(const std::string& referenceframe, const std::string& e
 	, m_fgeoidSep(0.), m_dmeridianDef(0.), m_dverticalDef(0.)
 	, m_lfileOrder(0), m_lnameOrder(0)
 	, m_zone(0), m_unusedStation(INVALID_STATION)
-	, m_referenceFrame(referenceframe), m_epoch(epoch)
+	, m_referenceFrame(referenceframe), m_epoch(epoch), m_observation_epoch(epoch)
 	, m_constraintType(free_3D)
 {
 	m_epsgCode = epsgStringFromName<std::string>(referenceframe);
@@ -170,6 +170,7 @@ CDnaStation::CDnaStation(const CDnaStation& newStation)
 	m_referenceFrame = newStation.m_referenceFrame;
 	m_epsgCode = newStation.m_epsgCode;
 	m_epoch = newStation.m_epoch;
+	m_observation_epoch = newStation.m_observation_epoch;
 
 	m_constraintType = newStation.m_constraintType;
 }
@@ -215,6 +216,7 @@ CDnaStation::CDnaStation(const std::string& strName, const std::string& strConst
 	m_referenceFrame = DEFAULT_DATUM;
 	m_epsgCode = DEFAULT_EPSG_S;
 	m_epoch = "";
+	m_observation_epoch = "";
 }
 
 CDnaStation& CDnaStation::operator =(const CDnaStation& rhs)
@@ -261,9 +263,10 @@ CDnaStation& CDnaStation::operator =(const CDnaStation& rhs)
 	m_referenceFrame = rhs.m_referenceFrame;
 	m_epsgCode = rhs.m_epsgCode;
 	m_epoch = rhs.m_epoch;
+	m_observation_epoch = rhs.m_observation_epoch;
 
 	m_constraintType = rhs.m_constraintType;
-	
+
 	return *this;
 }
 
@@ -675,6 +678,7 @@ void CDnaStation::WriteBinaryStn(std::ofstream* binary_stream, const UINT16 bUnu
 	stationRecord.unusedStation = bUnused;
 
 	strcpy(stationRecord.epoch, m_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
+	strcpy(stationRecord.observation_epoch, m_observation_epoch.substr(0, STN_EPOCH_WIDTH).c_str());
 	strcpy(stationRecord.epsgCode, m_epsgCode.substr(0, STN_EPSG_WIDTH).c_str());
 
 	binary_stream->write(reinterpret_cast<char *>(&stationRecord), sizeof(station_t));
@@ -948,6 +952,7 @@ void CDnaStation::SetStationRec(const station_t& stationRecord)
 	m_unusedStation = (stationRecord.unusedStation == VALID_STATION ? true : false);
 
 	m_epoch = stationRecord.epoch;
+	m_observation_epoch = stationRecord.observation_epoch;
 	m_epsgCode = stationRecord.epsgCode;
 	m_referenceFrame = datumFromEpsgCode<std::string, UINT32>(LongFromString<UINT32>(m_epsgCode));
 }

--- a/dynadjust/include/measurement_types/dnastation.hpp
+++ b/dynadjust/include/measurement_types/dnastation.hpp
@@ -276,9 +276,18 @@ public:
 
 	inline std::string GetReferenceFrame() const { return m_referenceFrame; }
 	inline std::string GetEpoch() const { return m_epoch; }
-	
+	inline std::string GetObservationEpoch() const { return m_observation_epoch; }
+
 	inline void SetReferenceFrame(const std::string& r) { m_referenceFrame = trimstr(r); }
-	inline void SetEpoch(const std::string& e) { m_epoch = trimstr(e); }
+	// Default observation_epoch to epoch when unset so legacy inputs preserve
+	// prior behaviour; once set, observation_epoch is immutable under reftran.
+	inline void SetEpoch(const std::string& e)
+	{
+		m_epoch = trimstr(e);
+		if (m_observation_epoch.empty())
+			m_observation_epoch = m_epoch;
+	}
+	inline void SetObservationEpoch(const std::string& e) { m_observation_epoch = trimstr(e); }
 	inline void SetEpsg(const std::string& e) { m_epsgCode = trimstr(e); }
 
 	std::string m_strName;
@@ -325,6 +334,7 @@ protected:
 	std::string	m_referenceFrame;
 	std::string	m_epsgCode;
 	std::string	m_epoch;
+	std::string	m_observation_epoch;
 
 	CONSTRAINT_TYPE m_constraintType;
 };

--- a/sampleData/DynaML.xsd
+++ b/sampleData/DynaML.xsd
@@ -43,6 +43,7 @@
 				<xs:element ref="Ignore" minOccurs="0"/>
 				<xs:element ref="ReferenceFrame" minOccurs="0"/>
 				<xs:element ref="Epoch" minOccurs="0"/>
+				<xs:element ref="EpochOfObservation" minOccurs="0"/>
 				<xs:element ref="First"/>
 				<xs:element ref="Second"/>
 				<xs:element ref="Third"/>
@@ -194,6 +195,7 @@
 	<xs:element name="Source" type="xs:string"/>
 	<xs:element name="ReferenceFrame" type="xs:string"/>
 	<xs:element name="Epoch" type="xs:string"/>
+	<xs:element name="EpochOfObservation" type="xs:string"/>
 	<xs:element name="MeasurementID" type="xs:string"/>
 	<xs:element name="ClusterID" type="xs:string"/>
 </xs:schema>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,22 @@ target_compile_definitions(test_format_elapsed_time PRIVATE
     __BINARY_DESC__="Unit tests for FormatElapsedTime helper (issue #351)"
 )
 
+# Test 12: DynadjustFile v1.1 back-compat test (issue #325)
+add_executable(test_dynadjust_file
+    test_dynadjust_file.cpp
+    ${IO_COMMON_SOURCES}
+)
+
+target_link_libraries(test_dynadjust_file
+    ${PLATFORM_LIBS}
+    ${Boost_LIBRARIES}
+)
+
+target_compile_definitions(test_dynadjust_file PRIVATE
+    __BINARY_NAME__="test_dynadjust_file"
+    __BINARY_DESC__="Unit tests for DynadjustFile v1.1 back-compat (issue #325)"
+)
+
 # Enable testing
 enable_testing()
 
@@ -244,16 +260,17 @@ add_test(NAME MeasurementProcessorTest COMMAND test_measurement_processor)
 add_test(NAME DynAdjustPrinterTest COMMAND test_dnaadjust_printer)
 add_test(NAME GNSSNstatSortTest COMMAND test_gnss_nstat_sort)
 add_test(NAME FormatElapsedTimeTest COMMAND test_format_elapsed_time)
+add_test(NAME DynadjustFileTest COMMAND test_dynadjust_file)
 
 # Custom target to run all tests
 add_custom_target(run_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --verbose
-    DEPENDS test_matrix test_msr_to_stn_sort test_bst_file test_asl_file test_aml_file_loader test_bms_file test_network_data_loader test_measurement_processor test_dnaadjust_printer test_gnss_nstat_sort test_format_elapsed_time
+    DEPENDS test_matrix test_msr_to_stn_sort test_bst_file test_asl_file test_aml_file_loader test_bms_file test_network_data_loader test_measurement_processor test_dnaadjust_printer test_gnss_nstat_sort test_format_elapsed_time test_dynadjust_file
     COMMENT "Running all tests"
 )
 
 # Custom target equivalent to 'make all'
 add_custom_target(tests_all
-    DEPENDS test_matrix test_msr_to_stn_sort test_bst_file test_asl_file test_aml_file_loader test_bms_file test_network_data_loader test_measurement_processor test_dnaadjust_printer test_gnss_nstat_sort test_format_elapsed_time
+    DEPENDS test_matrix test_msr_to_stn_sort test_bst_file test_asl_file test_aml_file_loader test_bms_file test_network_data_loader test_measurement_processor test_dnaadjust_printer test_gnss_nstat_sort test_format_elapsed_time test_dynadjust_file
     COMMENT "Building all tests"
 )

--- a/tests/test_bms_file.cpp
+++ b/tests/test_bms_file.cpp
@@ -555,3 +555,37 @@ TEST_CASE("Source file index round-trip", "[BmsFile][roundtrip][source]") {
 
     cleanup_temp_files();
 }
+
+TEST_CASE("observation_epoch round-trip preserves distinct values", "[BmsFile][observation_epoch]") {
+    BmsFile bms_loader;
+    vmsr_t measurements;
+    binary_file_meta_t meta;
+
+    cleanup_temp_files();
+
+    measurement_t msr = {};
+    msr.measType = 'G';
+    msr.measurementStations = 2;
+    snprintf(msr.epsgCode, sizeof(msr.epsgCode), "7843");
+    snprintf(msr.epoch, sizeof(msr.epoch), "01.01.2020");
+    snprintf(msr.observation_epoch, sizeof(msr.observation_epoch), "15.06.2015");
+    msr.station1 = 0;
+    msr.station2 = 1;
+    msr.term1 = 1234.5;
+    measurements.push_back(msr);
+
+    create_test_binary_meta(meta, measurements.size());
+    snprintf(meta.observation_epoch, sizeof(meta.observation_epoch), "15.06.2015");
+
+    bms_loader.WriteFile(TEMP_BMS_FILE, &measurements, meta);
+
+    vmsr_t loaded;
+    binary_file_meta_t loaded_meta;
+    bms_loader.LoadFile(TEMP_BMS_FILE, &loaded, loaded_meta);
+
+    REQUIRE(std::string(loaded[0].epoch) == "01.01.2020");
+    REQUIRE(std::string(loaded[0].observation_epoch) == "15.06.2015");
+    REQUIRE(std::string(loaded_meta.observation_epoch) == "15.06.2015");
+
+    cleanup_temp_files();
+}

--- a/tests/test_bst_file.cpp
+++ b/tests/test_bst_file.cpp
@@ -224,3 +224,42 @@ TEST_CASE("Write and read back synthetic data", "[BstFile]") {
 
     cleanup_temp_files();
 }
+
+TEST_CASE("observation_epoch round-trip preserves distinct epoch values", "[BstFile][observation_epoch]") {
+    BstFile bst_loader;
+    vstn_t stations;
+    binary_file_meta_t bst_meta;
+
+    cleanup_temp_files();
+
+    station_t stn;
+    snprintf(stn.stationName, sizeof(stn.stationName), "OBS001");
+    snprintf(stn.stationNameOrig, sizeof(stn.stationNameOrig), "OBS001_2015");
+    snprintf(stn.epoch, sizeof(stn.epoch), "01.01.2020");
+    snprintf(stn.observation_epoch, sizeof(stn.observation_epoch), "15.06.2015");
+    stn.initialLatitude = -35.0;
+    stn.currentLatitude = -35.0;
+    stn.initialLongitude = 149.0;
+    stn.currentLongitude = 149.0;
+    stn.initialHeight = 100.0;
+    stn.currentHeight = 100.0;
+    stn.zone = 55;
+    stn.fileOrder = 1;
+    stn.nameOrder = 1;
+    stations.push_back(stn);
+
+    create_test_binary_meta(bst_meta, static_cast<UINT32>(stations.size()));
+    snprintf(bst_meta.observation_epoch, sizeof(bst_meta.observation_epoch), "15.06.2015");
+
+    bst_loader.WriteFile(TEMP_BST_FILE, &stations, bst_meta);
+
+    vstn_t loaded;
+    binary_file_meta_t loaded_meta;
+    bst_loader.LoadFile(TEMP_BST_FILE, &loaded, loaded_meta);
+
+    REQUIRE(std::string(loaded[0].epoch) == "01.01.2020");
+    REQUIRE(std::string(loaded[0].observation_epoch) == "15.06.2015");
+    REQUIRE(std::string(loaded_meta.observation_epoch) == "15.06.2015");
+
+    cleanup_temp_files();
+}


### PR DESCRIPTION
Introduces a new Epoch of Observation concept, distinct from the existing reference-frame epoch, throughout the data model and binary formats. This means we have:
  - `epoch`: Epoch of Reference Frame (mutable by dnareftran).
  - `observation_epoch`: Timestamp of when the measurement/station was observed. Immutable under reftran.

One thing to note is that this means the binary file format needs to change and is not compatible anymore, which is not an issue since the binary format should only be used as an intermediary stage after `dnaimport` has ingested the XML files. The binary file format has been bumped from `1.1` to `1.2` and readers fall back `observation_epoch = epoch` for legacy files.

A new `--observation-epoch` option (accepts dd.mm.yyyy, year-only, or literal today) has been added.
